### PR TITLE
Add `db_parameter` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The module will create:
 - `copy_tags_to_snapshot` - Copy all tags from RDS database to snapshot. Default `true`
 - `backup_retention_period` - Backup retention period in days (default `0`). Must be `> 0` to enable backups
 - `backup_window` - When to perform DB snapshots. Default `"22:00-03:00"`. Can't overlap with the maintenance window
+- `db_parameter` -  A list of DB parameters to apply. Note that parameters may differ from a family to an other.
 
 
 
@@ -92,6 +93,11 @@ module "rds_instance" {
       copy_tags_to_snapshot       = true
       backup_retention_period     = 7
       backup_window               = "22:00-03:00"
+
+      db_parameter                = [
+        { name  = "myisam_sort_buffer_size"   value = "1048576" },
+        { name  = "sort_buffer_size"          value = "2097152" },
+      ]
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -37,9 +37,10 @@ resource "aws_db_instance" "default" {
 }
 
 resource "aws_db_parameter_group" "default" {
-  name   = "${module.label.id}"
-  family = "${var.db_parameter_group}"
-  tags   = "${module.label.tags}"
+  name      = "${module.label.id}"
+  family    = "${var.db_parameter_group}"
+  tags      = "${module.label.tags}"
+  parameter = "${var.db_parameter}"
 }
 
 resource "aws_db_subnet_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -148,3 +148,8 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "db_parameter" {
+  type = "list"
+  default = []
+}


### PR DESCRIPTION
## What
* Add `db_parameter` option

## Why
* Sometimes we need to add special parameters to the RDS database

## Plan
![image](https://user-images.githubusercontent.com/1134449/31443030-ed3f72be-aea0-11e7-8933-3a73dac9ac40.png)
