### PR TITLE
Add snapshot_identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The module will create:
 - `backup_retention_period` - Backup retention period in days (default `0`). Must be `> 0` to enable backups
 - `backup_window` - When to perform DB snapshots. Default `"22:00-03:00"`. Can't overlap with the maintenance window
 - `db_parameter` -  A list of DB parameters to apply. Note that parameters may differ from a family to an other
-- `snapshot_identifier` - Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05
+- `snapshot_identifier` - Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: `rds:production-2015-06-26-06-05`
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The module will create:
 - `dns_zone_id` - The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name
 - `host_name` - The DB host name created in Route53
 - `security_group_ids` - The IDs of the security groups from which to allow `ingress` traffic to the DB instance
-- `database_name` - The name of the database (_e.g._ `wordpress`)
-- `database_user` - Admin user name (_e.g._ `admin`)
-- `database_password` - Admin password
+- `database_name` -  (Optional) The name of the database to create when the DB instance is created
+- `database_user` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user
+- `database_password` - (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user
 - `database_port` - Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids`
 - `multi_az` - Default `false`. Set to `true` for a multi-AZ deployment (recommended for production)
 - `storage_type` - One of `standard` (magnetic), `gp2` (general purpose SSD), or `io1` (provisioned IOPS SSD). Default `standard` (magnetic)
@@ -36,7 +36,7 @@ The module will create:
 - `subnet_ids` - List of subnets IDs in the VPC, _e.g._ `["sb-1234567890", "sb-0987654321"]`
 - `vpc_id` - VPC ID the DB instance will be connected to
 - `auto_minor_version_upgrade` - Automatically upgrade minor version of the DB (eg. from Postgres 9.5.3 to Postgres 9.5.4). Default `true`
-- `allow_major_version_upgrade` - Allow upgrading of major version of database (eg. from Postgres 9.5.x to Postgres 9.6.x). Default `false`
+- `allow_major_version_upgrade` - Allow upgrading of major version of database. Default `false`. **Important**: if you are using a snapshot for creating an instance, this option should be set to `true` (if engine versions specified in the manifest and in the snapshot are different)
 - `apply_immediately` - Specifies whether any database modifications are applied immediately, or during the next maintenance window. Default `false`
 - `maintenance_window` - The window to perform maintenance in. Default `"Mon:03:00-Mon:04:00"`
 - `skip_final_snapshot` - If `true` (default), DB won't be backed up before deletion
@@ -45,6 +45,7 @@ The module will create:
 - `backup_window` - When to perform DB snapshots. Default `"22:00-03:00"`. Can't overlap with the maintenance window
 - `db_parameter` -  A list of DB parameters to apply. Note that parameters may differ from a family to an other
 - `snapshot_identifier` - Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: `rds:production-2015-06-26-06-05`
+- `final_snapshot_identifier` - Specifies whether or not to create a final snapshot for this database when destroing. This option **must** be set if `skip_final_snapshot` = `false`. E.g.: `"dbname-final-snapshot-${md5(timestamp())}"`
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The module will create:
 - `copy_tags_to_snapshot` - Copy all tags from RDS database to snapshot. Default `true`
 - `backup_retention_period` - Backup retention period in days (default `0`). Must be `> 0` to enable backups
 - `backup_window` - When to perform DB snapshots. Default `"22:00-03:00"`. Can't overlap with the maintenance window
-- `db_parameter` -  A list of DB parameters to apply. Note that parameters may differ from a family to an other.
-
+- `db_parameter` -  A list of DB parameters to apply. Note that parameters may differ from a family to an other
+- `snapshot_identifier` - Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05
 
 
 ## Outputs
@@ -85,6 +85,7 @@ module "rds_instance" {
       publicly_accessible         = false
       subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
       vpc_id                      = "vpc-xxxxxxxx"
+      snapshot_identifier         = "rds:production-2015-06-26-06-05"
       auto_minor_version_upgrade  = true
       allow_major_version_upgrade = false
       apply_immediately           = false

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ resource "aws_db_instance" "default" {
   storage_type                = "${var.storage_type}"
   iops                        = "${var.iops}"
   publicly_accessible         = "${var.publicly_accessible}"
+  snapshot_identifier         = "${var.snapshot_identifier}"
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
   auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
   apply_immediately           = "${var.apply_immediately}"

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "aws_db_instance" "default" {
   backup_retention_period     = "${var.backup_retention_period}"
   backup_window               = "${var.backup_window}"
   tags                        = "${module.label.tags}"
+  final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 }
 
 resource "aws_db_parameter_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,7 @@ variable "db_parameter" {
   type = "list"
   default = []
 }
+
+variable "snapshot_identifier" {
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -159,3 +159,6 @@ variable "snapshot_identifier" {
   default = ""
 }
 
+variable "final_snapshot_identifier" {
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,5 +155,7 @@ variable "db_parameter" {
 }
 
 variable "snapshot_identifier" {
+  description = "Snapshot name e.g: rds:production-2015-06-26-06-05"
   default = ""
 }
+


### PR DESCRIPTION
## What
* Add `snapshot_identifier`

## Why
* We need this option for restoring RDS instance from the snapshot

## Plan
![image](https://user-images.githubusercontent.com/1134449/32183051-dda89448-bda0-11e7-9259-24d30de74330.png)
