### PR TITLE
Use `splat + join` syntax for outputs from resources with counts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# terraform-aws-rds
+# terraform-aws-rds [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-rds.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-rds)
 
 Terraform module to provision AWS [`RDS`](https://aws.amazon.com/rds/) instances
 
 
 The module will create:
+
 * DB instance (MySQL, Postgres, SQL Server, Oracle)
 * DB Parameter Group
 * DB Subnet Group
@@ -11,8 +12,7 @@ The module will create:
 * DNS Record in Route53 for the DB endpoint
 
 
-
-## Input Variables
+## Inputs
 
 - `stage` - The deployment stage (_e.g._ `prod`, `staging`, `dev`)
 - `namespace` - The namespace of the application the DB instance belongs to (_e.g._ `global`, `shared`, or the name of your company like `cloudposse`)
@@ -49,6 +49,7 @@ The module will create:
 - `final_snapshot_identifier` - Specifies whether or not to create a final snapshot for this database when destroing. This option **must** be set if `skip_final_snapshot` = `false`. E.g.: `"dbname-final-snapshot-${md5(timestamp())}"`
 - `parameter_group_name` - (Optional) Name of the DB parameter group to associate (e.g. `mysql-5-6`)
 
+
 ## Outputs
 
 - `instance_id` - ID of the instance
@@ -60,15 +61,13 @@ The module will create:
 - `hostname` - DNS host name of the instance
 
 
-
 ## Usage
-
 
 ```hcl
 module "rds_instance" {
       source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
+      namespace                   = "cp"
       stage                       = "prod"
-      namespace                   = "cloudposse"
       name                        = "app"
       dns_zone_id                 = "Z89FN1IW975KPE"
       host_name                   = "db"
@@ -107,6 +106,85 @@ module "rds_instance" {
 ```
 
 
+## Help
+
+**Got a question?**
+
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-rds/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-rds/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing `terraform-aws-rds`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
+
+
 ## License
 
-Apache 2 License. See [`LICENSE`](LICENSE) for full details.
+[APACHE 2.0](LICENSE) © 2018 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [LICENSE](LICENSE) for full details.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+## About
+
+`terraform-aws-rds` is maintained and funded by [Cloud Posse, LLC][website].
+
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+
+
+Like it? Please let us know at <hello@cloudposse.com>
+
+We love [Open Source Software](https://github.com/cloudposse/)!
+
+See [our other projects][community]
+or [hire us][hire] to help build your next cloud platform.
+
+  [website]: https://cloudposse.com/
+  [community]: https://github.com/cloudposse/
+  [hire]: https://cloudposse.com/contact/
+
+
+## Contributors
+
+| [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img]
+|-------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|
+
+[erik_img]: http://s.gravatar.com/avatar/88c480d4f73b813904e00a5695a454cb?s=144
+[erik_web]: https://github.com/osterman/
+[andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
+[andriy_web]: https://github.com/aknysh/
+[igor_img]: http://s.gravatar.com/avatar/bc70834d32ed4517568a1feb0b9be7e2?s=144
+[igor_web]: https://github.com/goruha/

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,7 +1,7 @@
 module "rds_instance" {
-  source                      = "git::https://github.com/cloudposse/tf_rds.git?ref=tags/0.1.0"
+  source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
+  namespace                   = "cp"
   stage                       = "prod"
-  namespace                   = "cloudposse"
   name                        = "app"
   dns_zone_id                 = "Z89FN1IW975KPE"
   host_name                   = "db"
@@ -13,14 +13,16 @@ module "rds_instance" {
   multi_az                    = "true"
   storage_type                = "gp2"
   allocated_storage           = "100"
-  storage_encrypted           = "false"
+  storage_encrypted           = "true"
   engine                      = "mysql"
   engine_version              = "5.7.17"
   instance_class              = "db.t2.medium"
   db_parameter_group          = "mysql5.6"
+  parameter_group_name        = "mysql-5-6"
   publicly_accessible         = "false"
   subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
   vpc_id                      = "vpc-xxxxxxxx"
+  snapshot_identifier         = "rds:production-2015-06-26-06-05"
   auto_minor_version_upgrade  = "true"
   allow_major_version_upgrade = "false"
   apply_immediately           = "false"
@@ -29,4 +31,17 @@ module "rds_instance" {
   copy_tags_to_snapshot       = "true"
   backup_retention_period     = 7
   backup_window               = "22:00-03:00"
+
+  db_parameter = [
+    {
+      name = "myisam_sort_buffer_size"
+
+      value = "1048576"
+    },
+    {
+      name = "sort_buffer_size"
+
+      value = "2097152"
+    },
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"
@@ -9,12 +9,13 @@ module "label" {
 }
 
 module "final_snapshot_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
   attributes = ["${compact(concat(var.attributes, list("final", "snapshot")))}"]
+  tags       = "${var.tags}"
 }
 
 resource "aws_db_instance" "default" {
@@ -85,7 +86,7 @@ resource "aws_security_group" "default" {
 }
 
 module "dns_host_name" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.1.1"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.2"
   namespace = "${var.namespace}"
   name      = "${var.host_name}"
   stage     = "${var.stage}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "security_group_id" {
 }
 
 output "parameter_group_id" {
-  value = "${aws_db_parameter_group.default.id}"
+  value = "${join("", aws_db_parameter_group.default.*.id)}"
 }
 
 output "hostname" {


### PR DESCRIPTION
## what
* Use `splat + join` syntax for outputs from resources with counts
* Added TravisCI

## why
* To address the issue https://github.com/cloudposse/terraform-aws-rds/issues/10
* To fix terraform warnings
> Warning: output "parameter_group_id": must use splat syntax to access aws_db_parameter_group.default attribute "id", because it has "count" set; use aws_db_parameter_group.default.*.id to obtain a list of the attributes across all instances


