### PR TITLE
Make `database_user` and `database_password` optional. Make `dns_zone_id` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The module will create:
 ```hcl
 module "rds_instance" {
       source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
-      namespace                   = "cp"
+      namespace                   = "eg"
       stage                       = "prod"
       name                        = "app"
       dns_zone_id                 = "Z89FN1IW975KPE"
@@ -86,8 +86,9 @@ module "rds_instance" {
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```
@@ -99,40 +100,40 @@ Available targets:
 | allocated_storage | The allocated storage in GBs | string | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | string | `false` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
-| attributes |  | list | `<list>` | no |
-| auto_minor_version_upgrade | Allow automated minor version upgrade | string | `true` | no |
+| attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| auto_minor_version_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | string | `true` | no |
 | backup_retention_period | Backup retention period in days. Must be > 0 to enable backups | string | `0` | no |
 | backup_window | When AWS can perform DB snapshots, can't overlap with maintenance window | string | `22:00-03:00` | no |
 | copy_tags_to_snapshot | Copy tags from DB to a snapshot | string | `true` | no |
 | database_name | The name of the database to create when the DB instance is created | string | - | yes |
-| database_password | (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user | string | - | yes |
+| database_password | (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user | string | `` | no |
 | database_port | Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids` | string | - | yes |
-| database_user | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | string | - | yes |
-| db_parameter |  | list | `<list>` | no |
+| database_user | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | string | `` | no |
+| db_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | list | `<list>` | no |
 | db_parameter_group | Parameter group, depends on DB engine used | string | - | yes |
-| delimiter |  | string | `-` | no |
-| dns_zone_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | string | - | yes |
+| delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
+| dns_zone_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | string | `` | no |
 | engine | Database engine type | string | - | yes |
 | engine_version | Database engine version, depends on engine type | string | - | yes |
-| final_snapshot_identifier | Identifier e.g.: some-db-final-snapshot-2015-06-26-06-05 | string | `` | no |
+| final_snapshot_identifier | Final snapshot identifier e.g.: some-db-final-snapshot-2015-06-26-06-05 | string | `` | no |
 | host_name | The DB host name created in Route53 | string | `db` | no |
 | instance_class | Class of RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
-| security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | - | yes |
+| security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |
-| snapshot_identifier | Snapshot name e.g: rds:production-2015-06-26-06-05 | string | `` | no |
+| snapshot_identifier | Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | storage_encrypted | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified. | string | `false` | no |
 | storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). | string | `standard` | no |
 | subnet_ids | List of subnets for the DB | list | - | yes |
-| tags |  | map | `<map>` | no |
-| vpc_id | VPC ID the DB instance will be connected to - `auto_minor_version_upgrade` - Automatically upgrade minor version of the DB (eg. from Postgres 9.5.3 to Postgres 9.5.4). | string | `true` | no |
+| tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| vpc_id | VPC ID the DB instance will be created in | string | - | yes |
 
 ## Outputs
 
@@ -273,9 +274,11 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
 
 ### Contributors
 
-|  [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Valeriy][drama17_avatar]][drama17_homepage]<br/>[Valeriy][drama17_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![drmikecrowe][drmikecrowe_avatar]][drmikecrowe_homepage]<br/>[drmikecrowe][drmikecrowe_homepage] |
-|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Valeriy][drama17_avatar]][drama17_homepage]<br/>[Valeriy][drama17_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![drmikecrowe][drmikecrowe_avatar]][drmikecrowe_homepage]<br/>[drmikecrowe][drmikecrowe_homepage] |
+|---|---|---|---|---|---|
 
+  [osterman_homepage]: https://github.com/osterman
+  [osterman_avatar]: https://github.com/osterman.png?size=150
   [aknysh_homepage]: https://github.com/aknysh
   [aknysh_avatar]: https://github.com/aknysh.png?size=150
   [s2504s_homepage]: https://github.com/s2504s

--- a/README.yaml
+++ b/README.yaml
@@ -55,7 +55,7 @@ usage: |-
   ```hcl
   module "rds_instance" {
         source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
-        namespace                   = "cp"
+        namespace                   = "eg"
         stage                       = "prod"
         name                        = "app"
         dns_zone_id                 = "Z89FN1IW975KPE"
@@ -100,6 +100,8 @@ include:
 
 # Contributors to this project
 contributors:
+  - name: "Erik Osterman"
+    github: "osterman"
   - name: "Andriy Knysh"
     github: "aknysh"
   - name: "Sergey Vasilyev"

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -2,8 +2,9 @@
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,40 +6,40 @@
 | allocated_storage | The allocated storage in GBs | string | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | string | `false` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
-| attributes |  | list | `<list>` | no |
-| auto_minor_version_upgrade | Allow automated minor version upgrade | string | `true` | no |
+| attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| auto_minor_version_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | string | `true` | no |
 | backup_retention_period | Backup retention period in days. Must be > 0 to enable backups | string | `0` | no |
 | backup_window | When AWS can perform DB snapshots, can't overlap with maintenance window | string | `22:00-03:00` | no |
 | copy_tags_to_snapshot | Copy tags from DB to a snapshot | string | `true` | no |
 | database_name | The name of the database to create when the DB instance is created | string | - | yes |
-| database_password | (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user | string | - | yes |
+| database_password | (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user | string | `` | no |
 | database_port | Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids` | string | - | yes |
-| database_user | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | string | - | yes |
-| db_parameter |  | list | `<list>` | no |
+| database_user | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | string | `` | no |
+| db_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | list | `<list>` | no |
 | db_parameter_group | Parameter group, depends on DB engine used | string | - | yes |
-| delimiter |  | string | `-` | no |
-| dns_zone_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | string | - | yes |
+| delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
+| dns_zone_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | string | `` | no |
 | engine | Database engine type | string | - | yes |
 | engine_version | Database engine version, depends on engine type | string | - | yes |
-| final_snapshot_identifier | Identifier e.g.: some-db-final-snapshot-2015-06-26-06-05 | string | `` | no |
+| final_snapshot_identifier | Final snapshot identifier e.g.: some-db-final-snapshot-2015-06-26-06-05 | string | `` | no |
 | host_name | The DB host name created in Route53 | string | `db` | no |
 | instance_class | Class of RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
-| security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | - | yes |
+| security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |
-| snapshot_identifier | Snapshot name e.g: rds:production-2015-06-26-06-05 | string | `` | no |
+| snapshot_identifier | Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | storage_encrypted | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified. | string | `false` | no |
 | storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). | string | `standard` | no |
 | subnet_ids | List of subnets for the DB | list | - | yes |
-| tags |  | map | `<map>` | no |
-| vpc_id | VPC ID the DB instance will be connected to - `auto_minor_version_upgrade` - Automatically upgrade minor version of the DB (eg. from Postgres 9.5.3 to Postgres 9.5.4). | string | `true` | no |
+| tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| vpc_id | VPC ID the DB instance will be created in | string | - | yes |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,6 @@
 module "rds_instance" {
   source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
-  namespace                   = "cp"
+  namespace                   = "eg"
   stage                       = "prod"
   name                        = "app"
   dns_zone_id                 = "Z89FN1IW975KPE"

--- a/main.tf
+++ b/main.tf
@@ -86,10 +86,11 @@ resource "aws_security_group" "default" {
 }
 
 module "dns_host_name" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.2"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
   namespace = "${var.namespace}"
   name      = "${var.host_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.dns_zone_id}"
   records   = ["${aws_db_instance.default.address}"]
+  enabled   = "${length(var.dns_zone_id) > 0 ? "true" : "false"}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,38 +1,50 @@
 variable "name" {
+  type        = "string"
   description = "The Name of the application or solution  (e.g. `bastion` or `portal`)"
 }
 
 variable "namespace" {
-  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  type        = "string"
+  description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
+  type        = "string"
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "dns_zone_id" {
+  type        = "string"
+  default     = ""
   description = "The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name"
 }
 
 variable "host_name" {
+  type        = "string"
   default     = "db"
   description = "The DB host name created in Route53"
 }
 
 variable "security_group_ids" {
   type        = "list"
+  default     = []
   description = "he IDs of the security groups from which to allow `ingress` traffic to the DB instance"
 }
 
 variable "database_name" {
+  type        = "string"
   description = "The name of the database to create when the DB instance is created"
 }
 
 variable "database_user" {
+  type        = "string"
+  default     = ""
   description = "(Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user"
 }
 
 variable "database_password" {
+  type        = "string"
+  default     = ""
   description = "(Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user"
 }
 
@@ -41,16 +53,19 @@ variable "database_port" {
 }
 
 variable "multi_az" {
+  type        = "string"
   description = "Set to true if multi AZ deployment must be supported"
   default     = "false"
 }
 
 variable "storage_type" {
+  type        = "string"
   description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD)."
   default     = "standard"
 }
 
 variable "storage_encrypted" {
+  type        = "string"
   description = "(Optional) Specifies whether the DB instance is encrypted. The default is false if not specified."
   default     = "false"
 }
@@ -67,6 +82,7 @@ variable "allocated_storage" {
 }
 
 variable "engine" {
+  type        = "string"
   description = "Database engine type"
 
   # http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
@@ -77,12 +93,14 @@ variable "engine" {
 }
 
 variable "engine_version" {
+  type        = "string"
   description = "Database engine version, depends on engine type"
 
   # http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
 }
 
 variable "instance_class" {
+  type        = "string"
   description = "Class of RDS instance"
 
   # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
@@ -91,6 +109,7 @@ variable "instance_class" {
 # This is for custom parameters to be passed to the DB
 # We're "cloning" default ones, but we need to specify which should be copied
 variable "db_parameter_group" {
+  type        = "string"
   description = "Parameter group, depends on DB engine used"
 
   # "mysql5.6"
@@ -98,6 +117,7 @@ variable "db_parameter_group" {
 }
 
 variable "publicly_accessible" {
+  type        = "string"
   description = "Determines if database can be publicly available (NOT recommended)"
   default     = "false"
 }
@@ -109,36 +129,41 @@ variable "subnet_ids" {
 
 variable "vpc_id" {
   type        = "string"
-  default     = "true"
-  description = "VPC ID the DB instance will be connected to - `auto_minor_version_upgrade` - Automatically upgrade minor version of the DB (eg. from Postgres 9.5.3 to Postgres 9.5.4)."
+  description = "VPC ID the DB instance will be created in"
 }
 
 variable "auto_minor_version_upgrade" {
-  description = "Allow automated minor version upgrade"
+  type        = "string"
+  description = "Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4)"
   default     = "true"
 }
 
 variable "allow_major_version_upgrade" {
+  type        = "string"
   description = "Allow major version upgrade"
   default     = "false"
 }
 
 variable "apply_immediately" {
+  type        = "string"
   description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
   default     = "false"
 }
 
 variable "maintenance_window" {
+  type        = "string"
   description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC "
   default     = "Mon:03:00-Mon:04:00"
 }
 
 variable "skip_final_snapshot" {
+  type        = "string"
   description = "If true (default), no snapshot will be made before deleting DB"
   default     = "true"
 }
 
 variable "copy_tags_to_snapshot" {
+  type        = "string"
   description = "Copy tags from DB to a snapshot"
   default     = "true"
 }
@@ -149,42 +174,49 @@ variable "backup_retention_period" {
 }
 
 variable "backup_window" {
+  type        = "string"
   description = "When AWS can perform DB snapshots, can't overlap with maintenance window"
   default     = "22:00-03:00"
 }
 
 variable "delimiter" {
-  type    = "string"
-  default = "-"
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type    = "list"
-  default = []
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type    = "map"
-  default = {}
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "db_parameter" {
-  type    = "list"
-  default = []
+  type        = "list"
+  default     = []
+  description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"
 }
 
 variable "snapshot_identifier" {
-  description = "Snapshot name e.g: rds:production-2015-06-26-06-05"
+  type        = "string"
+  description = "Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot"
   default     = ""
 }
 
 variable "final_snapshot_identifier" {
-  description = "Identifier e.g.: some-db-final-snapshot-2015-06-26-06-05"
   type        = "string"
+  description = "Final snapshot identifier e.g.: some-db-final-snapshot-2015-06-26-06-05"
   default     = ""
 }
 
 variable "parameter_group_name" {
+  type        = "string"
   description = "Name of the DB parameter group to associate"
   default     = ""
 }


### PR DESCRIPTION
## what
* Make `database_user` and `database_password` optional
* Make `dns_zone_id` optional

## why
* https://github.com/cloudposse/terraform-aws-rds/issues/15
* If `snapshot_identifier` is provided to restore the database from the snapshot, `database_user` and `database_password` are not required and TF should not ask for it
* Not all applications require creating Route53 sub-domains for the DB host
 