### PR TITLE
Added support for license_model and option_group creation needed for some db engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ module "rds_instance" {
       storage_encrypted           = "true"
       engine                      = "mysql"
       engine_version              = "5.7.17"
+      major_engine_version        = "5.7"
       instance_class              = "db.t2.medium"
       db_parameter_group          = "mysql5.6"
       parameter_group_name        = "mysql-5-6"
@@ -146,6 +147,7 @@ Available targets:
 | instance_class | Class of RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
+| major_engine_version | Similar to engine_version, but specifies the major version of the engine (i.e, 5.7) | string | `` | yes |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "rds_instance" {
       instance_class              = "db.t2.medium"
       db_parameter_group          = "mysql5.6"
       parameter_group_name        = "mysql-5-6"
-      option_group_name           " "mysql-options"
+      option_group_name           = "mysql-options"
       publicly_accessible         = "false"
       subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
       vpc_id                      = "vpc-xxxxxxxx"
@@ -149,7 +149,7 @@ Available targets:
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
-| option_group_name | Name of the Option group to associate | string | `` | no |
+| option_group_name | Name of the option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
@@ -170,6 +170,7 @@ Available targets:
 | instance_address | Address of the instance |
 | instance_endpoint | DNS Endpoint of the instance |
 | instance_id | ID of the instance |
+| option_group_id | ID of the Option Group |
 | parameter_group_id | ID of the Parameter Group |
 | security_group_id | ID of the Security Group |
 | subnet_group_id | ID of the Subnet Group |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 The module will create:
 
 * DB instance (MySQL, Postgres, SQL Server, Oracle)
+* DB Option Group (will create a new one or you may use an existing)
 * DB Parameter Group
 * DB Subnet Group
 * DB Security Group
@@ -53,54 +54,54 @@ The module will create:
 
 ```hcl
 module "rds_instance" {
-      source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
-      namespace                   = "eg"
-      stage                       = "prod"
-      name                        = "app"
-      dns_zone_id                 = "Z89FN1IW975KPE"
-      host_name                   = "db"
-      security_group_ids          = ["sg-xxxxxxxx"]
-      database_name               = "wordpress"
-      database_user               = "admin"
-      database_password           = "xxxxxxxxxxxx"
-      database_port               = 3306
-      multi_az                    = "true"
-      storage_type                = "gp2"
-      allocated_storage           = "100"
-      storage_encrypted           = "true"
-      engine                      = "mysql"
-      engine_version              = "5.7.17"
-      major_engine_version        = "5.7"
-      instance_class              = "db.t2.medium"
-      db_parameter_group          = "mysql5.6"
-      parameter_group_name        = "mysql-5-6"
-      option_group_name           = "mysql-options"
-      publicly_accessible         = "false"
-      subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
-      vpc_id                      = "vpc-xxxxxxxx"
-      snapshot_identifier         = "rds:production-2015-06-26-06-05"
-      auto_minor_version_upgrade  = "true"
-      allow_major_version_upgrade = "false"
-      apply_immediately           = "false"
-      maintenance_window          = "Mon:03:00-Mon:04:00"
-      skip_final_snapshot         = "false"
-      copy_tags_to_snapshot       = "true"
-      backup_retention_period     = 7
-      backup_window               = "22:00-03:00"
+    source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
+    namespace                   = "eg"
+    stage                       = "prod"
+    name                        = "app"
+    dns_zone_id                 = "Z89FN1IW975KPE"
+    host_name                   = "db"
+    security_group_ids          = ["sg-xxxxxxxx"]
+    database_name               = "wordpress"
+    database_user               = "admin"
+    database_password           = "xxxxxxxxxxxx"
+    database_port               = 3306
+    multi_az                    = "true"
+    storage_type                = "gp2"
+    allocated_storage           = "100"
+    storage_encrypted           = "true"
+    engine                      = "mysql"
+    engine_version              = "5.7.17"
+    major_engine_version        = "5.7"
+    instance_class              = "db.t2.medium"
+    db_parameter_group          = "mysql5.6"
+    parameter_group_name        = "mysql-5-6"
+    option_group_name           = "mysql-options"
+    publicly_accessible         = "false"
+    subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
+    vpc_id                      = "vpc-xxxxxxxx"
+    snapshot_identifier         = "rds:production-2015-06-26-06-05"
+    auto_minor_version_upgrade  = "true"
+    allow_major_version_upgrade = "false"
+    apply_immediately           = "false"
+    maintenance_window          = "Mon:03:00-Mon:04:00"
+    skip_final_snapshot         = "false"
+    copy_tags_to_snapshot       = "true"
+    backup_retention_period     = 7
+    backup_window               = "22:00-03:00"
 
-      db_parameter                = [
-        { name  = "myisam_sort_buffer_size"   value = "1048576" },
-        { name  = "sort_buffer_size"          value = "2097152" },
-      ]
-    
-      db_options                  = [
-        { option_name = "MARIADB_AUDIT_PLUGIN"
-            option_settings = [
-              { name = "SERVER_AUDIT_EVENTS"           value = "CONNECT" },
-              { name = "SERVER_AUDIT_FILE_ROTATIONS"   value = "37" }
-            ]
-        }
-      ]
+    db_parameter                = [
+      { name  = "myisam_sort_buffer_size"   value = "1048576" },
+      { name  = "sort_buffer_size"          value = "2097152" },
+    ]
+
+    db_options                  = [
+      { option_name = "MARIADB_AUDIT_PLUGIN"
+          option_settings = [
+            { name = "SERVER_AUDIT_EVENTS"           value = "CONNECT" },
+            { name = "SERVER_AUDIT_FILE_ROTATIONS"   value = "37" }
+          ]
+      }
+    ]
 }
 ```
 
@@ -135,6 +136,7 @@ Available targets:
 | database_password | (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user | string | `` | no |
 | database_port | Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids` | string | - | yes |
 | database_user | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | string | `` | no |
+| db_options | A list of DB options to apply with an option group.  Depends on DB engine | list | `<list>` | no |
 | db_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | list | `<list>` | no |
 | db_parameter_group | Parameter group, depends on DB engine used | string | - | yes |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
@@ -146,12 +148,13 @@ Available targets:
 | host_name | The DB host name created in Route53 | string | `db` | no |
 | instance_class | Class of RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
+| license_model | License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license | string | `` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
-| major_engine_version | Similar to engine_version, but specifies the major version of the engine (i.e, 5.7) | string | `` | yes |
+| major_engine_version | Database MAJOR engine version, depends on engine type | string | - | yes |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
-| option_group_name | Name of the option group to associate | string | `` | no |
+| option_group_name | Name of the DB option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Available targets:
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
 | license_model | License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license | string | `` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
-| major_engine_version | Database MAJOR engine version, depends on engine type | string | - | yes |
+| major_engine_version | Database MAJOR engine version, depends on engine type | string | `` | no |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ module "rds_instance" {
       instance_class              = "db.t2.medium"
       db_parameter_group          = "mysql5.6"
       parameter_group_name        = "mysql-5-6"
+      option_group_name           " "mysql-options"
       publicly_accessible         = "false"
       subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
       vpc_id                      = "vpc-xxxxxxxx"
@@ -89,6 +90,15 @@ module "rds_instance" {
       db_parameter                = [
         { name  = "myisam_sort_buffer_size"   value = "1048576" },
         { name  = "sort_buffer_size"          value = "2097152" },
+      ]
+    
+      db_options                  = [
+        { option_name = "MARIADB_AUDIT_PLUGIN"
+            option_settings = [
+              { name = "SERVER_AUDIT_EVENTS"           value = "CONNECT" },
+              { name = "SERVER_AUDIT_FILE_ROTATIONS"   value = "37" }
+            ]
+        }
       ]
 }
 ```
@@ -139,6 +149,7 @@ Available targets:
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
+| option_group_name | Name of the Option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -69,43 +69,54 @@ introduction: |-
 usage: |-
   ```hcl
   module "rds_instance" {
-        source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
-        namespace                   = "eg"
-        stage                       = "prod"
-        name                        = "app"
-        dns_zone_id                 = "Z89FN1IW975KPE"
-        host_name                   = "db"
-        security_group_ids          = ["sg-xxxxxxxx"]
-        database_name               = "wordpress"
-        database_user               = "admin"
-        database_password           = "xxxxxxxxxxxx"
-        database_port               = 3306
-        multi_az                    = "true"
-        storage_type                = "gp2"
-        allocated_storage           = "100"
-        storage_encrypted           = "true"
-        engine                      = "mysql"
-        engine_version              = "5.7.17"
-        instance_class              = "db.t2.medium"
-        db_parameter_group          = "mysql5.6"
-        parameter_group_name        = "mysql-5-6"
-        publicly_accessible         = "false"
-        subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
-        vpc_id                      = "vpc-xxxxxxxx"
-        snapshot_identifier         = "rds:production-2015-06-26-06-05"
-        auto_minor_version_upgrade  = "true"
-        allow_major_version_upgrade = "false"
-        apply_immediately           = "false"
-        maintenance_window          = "Mon:03:00-Mon:04:00"
-        skip_final_snapshot         = "false"
-        copy_tags_to_snapshot       = "true"
-        backup_retention_period     = 7
-        backup_window               = "22:00-03:00"
+      source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=master"
+      namespace                   = "eg"
+      stage                       = "prod"
+      name                        = "app"
+      dns_zone_id                 = "Z89FN1IW975KPE"
+      host_name                   = "db"
+      security_group_ids          = ["sg-xxxxxxxx"]
+      database_name               = "wordpress"
+      database_user               = "admin"
+      database_password           = "xxxxxxxxxxxx"
+      database_port               = 3306
+      multi_az                    = "true"
+      storage_type                = "gp2"
+      allocated_storage           = "100"
+      storage_encrypted           = "true"
+      engine                      = "mysql"
+      engine_version              = "5.7.17"
+      major_engine_version        = "5.7"
+      instance_class              = "db.t2.medium"
+      db_parameter_group          = "mysql5.6"
+      parameter_group_name        = "mysql-5-6"
+      option_group_name           = "mysql-options"
+      publicly_accessible         = "false"
+      subnet_ids                  = ["sb-xxxxxxxxx", "sb-xxxxxxxxx"]
+      vpc_id                      = "vpc-xxxxxxxx"
+      snapshot_identifier         = "rds:production-2015-06-26-06-05"
+      auto_minor_version_upgrade  = "true"
+      allow_major_version_upgrade = "false"
+      apply_immediately           = "false"
+      maintenance_window          = "Mon:03:00-Mon:04:00"
+      skip_final_snapshot         = "false"
+      copy_tags_to_snapshot       = "true"
+      backup_retention_period     = 7
+      backup_window               = "22:00-03:00"
 
-        db_parameter                = [
-          { name  = "myisam_sort_buffer_size"   value = "1048576" },
-          { name  = "sort_buffer_size"          value = "2097152" },
-        ]
+      db_parameter                = [
+        { name  = "myisam_sort_buffer_size"   value = "1048576" },
+        { name  = "sort_buffer_size"          value = "2097152" },
+      ]
+
+      db_options                  = [
+        { option_name = "MARIADB_AUDIT_PLUGIN"
+            option_settings = [
+              { name = "SERVER_AUDIT_EVENTS"           value = "CONNECT" },
+              { name = "SERVER_AUDIT_FILE_ROTATIONS"   value = "37" }
+            ]
+        }
+      ]
   }
   ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -59,6 +59,7 @@ introduction: |-
   The module will create:
 
   * DB instance (MySQL, Postgres, SQL Server, Oracle)
+  * DB Option Group (will create a new one or you may use an existing)
   * DB Parameter Group
   * DB Subnet Group
   * DB Security Group

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,7 @@
 | database_password | (Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user | string | `` | no |
 | database_port | Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids` | string | - | yes |
 | database_user | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | string | `` | no |
+| db_options | A list of DB options to apply with an option group.  Depends on DB engine | list | `<list>` | no |
 | db_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | list | `<list>` | no |
 | db_parameter_group | Parameter group, depends on DB engine used | string | - | yes |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
@@ -25,10 +26,13 @@
 | host_name | The DB host name created in Route53 | string | `db` | no |
 | instance_class | Class of RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
+| license_model | License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license | string | `` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
+| major_engine_version | Database MAJOR engine version, depends on engine type | string | - | yes |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
+| option_group_name | Name of the DB option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
@@ -49,6 +53,7 @@
 | instance_address | Address of the instance |
 | instance_endpoint | DNS Endpoint of the instance |
 | instance_id | ID of the instance |
+| option_group_id | ID of the Option Group |
 | parameter_group_id | ID of the Parameter Group |
 | security_group_id | ID of the Security Group |
 | subnet_group_id | ID of the Subnet Group |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -28,7 +28,7 @@
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'. Default is 0 if rds storage type is not 'io1' | string | `0` | no |
 | license_model | License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license | string | `` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | string | `Mon:03:00-Mon:04:00` | no |
-| major_engine_version | Database MAJOR engine version, depends on engine type | string | - | yes |
+| major_engine_version | Database MAJOR engine version, depends on engine type | string | `` | no |
 | multi_az | Set to true if multi AZ deployment must be supported | string | `false` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,8 @@ resource "aws_db_instance" "default" {
   vpc_security_group_ids      = ["${join("", aws_security_group.default.*.id)}"]
   db_subnet_group_name        = "${join("", aws_db_subnet_group.default.*.name)}"
   parameter_group_name        = "${length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)}"
-  option_group_name	      = "${length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)}"
-  license_model		      = "${var.license_model}"
+  option_group_name           = "${length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)}"
+  license_model               = "${var.license_model}"
   multi_az                    = "${var.multi_az}"
   storage_type                = "${var.storage_type}"
   iops                        = "${var.iops}"
@@ -67,6 +67,7 @@ resource "aws_db_option_group" "default" {
   major_engine_version = "${var.major_engine_version}"
   tags                 = "${module.label.tags}"
   option               = "${var.db_options}"
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,8 @@ resource "aws_db_instance" "default" {
   vpc_security_group_ids      = ["${join("", aws_security_group.default.*.id)}"]
   db_subnet_group_name        = "${join("", aws_db_subnet_group.default.*.name)}"
   parameter_group_name        = "${length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)}"
+  option_group_name	      = "${length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)}"
+  license_model		      = "${var.license_model}"
   multi_az                    = "${var.multi_az}"
   storage_type                = "${var.storage_type}"
   iops                        = "${var.iops}"
@@ -55,7 +57,19 @@ resource "aws_db_parameter_group" "default" {
   name      = "${module.label.id}"
   family    = "${var.db_parameter_group}"
   tags      = "${module.label.tags}"
-  parameter = "${var.db_parameter}"
+  parameter = "${var.db_options}"
+}
+
+resource "aws_db_option_group" "default" {
+  count                = "${(length(var.option_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
+  name                 = "${module.label.id}"
+  engine_name          = "${var.engine}"
+  major_engine_version = "${var.major_engine}"
+  tags                 = "${module.label.tags}"
+  option               = "${var.db_options}"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_subnet_group" "default" {

--- a/main.tf
+++ b/main.tf
@@ -57,14 +57,14 @@ resource "aws_db_parameter_group" "default" {
   name      = "${module.label.id}"
   family    = "${var.db_parameter_group}"
   tags      = "${module.label.tags}"
-  parameter = "${var.db_options}"
+  parameter = "${var.db_parameter}"
 }
 
 resource "aws_db_option_group" "default" {
   count                = "${(length(var.option_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
   name                 = "${module.label.id}"
   engine_name          = "${var.engine}"
-  major_engine_version = "${var.major_engine}"
+  major_engine_version = "${var.major_engine_version}"
   tags                 = "${module.label.tags}"
   option               = "${var.db_options}"
   lifecycle {

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,12 @@ output "parameter_group_id" {
   description = "ID of the Parameter Group"
 }
 
+output "option_group_id" {
+  value       = "${join("", aws_db_option_group.default.*.id)}"
+  description = "ID of the Option Group"
+}
+
+
 output "hostname" {
   value       = "${module.dns_host_name.hostname}"
   description = "DNS host name of the instance"

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,7 +33,6 @@ output "option_group_id" {
   description = "ID of the Option Group"
 }
 
-
 output "hostname" {
   value       = "${module.dns_host_name.hostname}"
   description = "DNS host name of the instance"

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,7 @@ variable "engine_version" {
 variable "major_engine_version" {
   type        = "string"
   description = "Database MAJOR engine version, depends on engine type"
+  default     = ""
 
   # https://docs.aws.amazon.com/cli/latest/reference/rds/create-option-group.html
 }

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,7 @@ variable "engine_version" {
 variable "major_engine_version" {
   type        = "string"
   description = "Database MAJOR engine version, depends on engine type"
+  default     = ""
 
   # https://docs.aws.amazon.com/cli/latest/reference/rds/create-option-group.html
 }
@@ -114,6 +115,7 @@ variable "major_engine_version" {
 variable "license_model" {
   type        = "string"
   description = "License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license"
+  default = ""
 }
 
 variable "instance_class" {
@@ -241,5 +243,11 @@ variable "final_snapshot_identifier" {
 variable "parameter_group_name" {
   type        = "string"
   description = "Name of the DB parameter group to associate"
+  default     = ""
+}
+
+variable "option_group_name" {
+  type        = "string"
+  description = "Name of the DB option group to associate"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,18 @@ variable "engine_version" {
   # http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
 }
 
+variable "major_engine_version" {
+  type        = "string"
+  description = "Database MAJOR engine version, depends on engine type"
+
+  # https://docs.aws.amazon.com/cli/latest/reference/rds/create-option-group.html
+}
+
+variable "license_model" {
+  type        = "string"
+  description = "License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license"
+}
+
 variable "instance_class" {
   type        = "string"
   description = "Class of RDS instance"
@@ -206,6 +218,12 @@ variable "db_parameter" {
   type        = "list"
   default     = []
   description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"
+}
+
+variable "db_options" {
+  type	      = "list"
+  default     = "[]"
+  description = "A list of DB options to apply with an option group.  Depends on DB engine"
 }
 
 variable "snapshot_identifier" {

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,6 @@ variable "engine_version" {
 variable "major_engine_version" {
   type        = "string"
   description = "Database MAJOR engine version, depends on engine type"
-  default     = ""
 
   # https://docs.aws.amazon.com/cli/latest/reference/rds/create-option-group.html
 }
@@ -115,7 +114,7 @@ variable "major_engine_version" {
 variable "license_model" {
   type        = "string"
   description = "License model for this DB.  Optional, but required for some DB Engines. Valid values: license-included | bring-your-own-license | general-public-license"
-  default = ""
+  default     = ""
 }
 
 variable "instance_class" {

--- a/variables.tf
+++ b/variables.tf
@@ -221,8 +221,8 @@ variable "db_parameter" {
 }
 
 variable "db_options" {
-  type	      = "list"
-  default     = "[]"
+  type        = "list"
+  default     = []
   description = "A list of DB options to apply with an option group.  Depends on DB engine"
 }
 


### PR DESCRIPTION
RE: https://www.terraform.io/docs/providers/aws/r/db_instance.html

- Added support for the license_model parameter, required for some engines like SQL Server.   Defaults to empty string, and AWS will fill this in with open source database engines, but it's required for commercial ones.  

- Added support for the db_option_group - and is modeled after the parameter_group feature in this model.   The module will always create it, but the user can point to an existing one.

- Tested both features where the end user defines these features, or doesn't.
