### PR TITLE
Added `server_security_group_ids`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ Available targets:
 | option_group_name | Name of the DB option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
-| security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
+| security_group_ids | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
+| server_security_group_ids | The IDs of the security groups which should be added to the DB instance. i.e. to allow other security groups to target this instance indirectly | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |
 | snapshot_identifier | Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Available targets:
 | allocated_storage | The allocated storage in GBs | string | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | string | `false` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
+| associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | auto_minor_version_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | string | `true` | no |
 | backup_retention_period | Backup retention period in days. Must be > 0 to enable backups | string | `0` | no |
@@ -164,7 +165,6 @@ Available targets:
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
-| server_security_group_ids | The IDs of the security groups which should be added to the DB instance. i.e. to allow other security groups to target this instance indirectly | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |
 | snapshot_identifier | Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,7 +36,8 @@
 | option_group_name | Name of the DB option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
-| security_group_ids | he IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
+| security_group_ids | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
+| server_security_group_ids | The IDs of the security groups which should be added to the DB instance. i.e. to allow other security groups to target this instance indirectly | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |
 | snapshot_identifier | Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,6 +5,7 @@
 | allocated_storage | The allocated storage in GBs | string | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | string | `false` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
+| associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | auto_minor_version_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | string | `true` | no |
 | backup_retention_period | Backup retention period in days. Must be > 0 to enable backups | string | `0` | no |
@@ -37,7 +38,6 @@
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | string | `false` | no |
 | security_group_ids | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
-| server_security_group_ids | The IDs of the security groups which should be added to the DB instance. i.e. to allow other security groups to target this instance indirectly | list | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | string | `true` | no |
 | snapshot_identifier | Snapshot identifier e.g: rds:production-2015-06-26-06-05. If specified, the module create cluster from the snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "default" {
   allocated_storage           = "${var.allocated_storage}"
   storage_encrypted           = "${var.storage_encrypted}"
   kms_key_id                  = "${var.kms_key_arn}"
-  vpc_security_group_ids      = ["${join("", aws_security_group.default.*.id)}"]
+  vpc_security_group_ids      = ["${join("", aws_security_group.default.*.id)}", "${var.server_security_group_ids}"]
   db_subnet_group_name        = "${join("", aws_db_subnet_group.default.*.name)}"
   parameter_group_name        = "${length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)}"
   option_group_name           = "${length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)}"

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "default" {
   allocated_storage           = "${var.allocated_storage}"
   storage_encrypted           = "${var.storage_encrypted}"
   kms_key_id                  = "${var.kms_key_arn}"
-  vpc_security_group_ids      = ["${join("", aws_security_group.default.*.id)}", "${var.server_security_group_ids}"]
+  vpc_security_group_ids      = ["${compact(concat(list(join("", aws_security_group.default.*.id)), var.associate_security_group_ids))}"]
   db_subnet_group_name        = "${join("", aws_db_subnet_group.default.*.name)}"
   parameter_group_name        = "${length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)}"
   option_group_name           = "${length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)}"

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "security_group_ids" {
   description = "The IDs of the security groups from which to allow `ingress` traffic to the DB instance"
 }
 
-variable "server_security_group_ids" {
+variable "associate_security_group_ids" {
   type        = "list"
   default     = []
   description = "The IDs of the existing security groups to associate with the DB instance"

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "security_group_ids" {
 variable "server_security_group_ids" {
   type        = "list"
   default     = []
-  description = "The IDs of the security groups which should be added to the DB instance. i.e. to allow other security groups to target this instance indirectly"
+  description = "The IDs of the existing security groups to associate with the DB instance"
 }
 
 variable "database_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,13 @@ variable "host_name" {
 variable "security_group_ids" {
   type        = "list"
   default     = []
-  description = "he IDs of the security groups from which to allow `ingress` traffic to the DB instance"
+  description = "The IDs of the security groups from which to allow `ingress` traffic to the DB instance"
+}
+
+variable "server_security_group_ids" {
+  type        = "list"
+  default     = []
+  description = "The IDs of the security groups which should be added to the DB instance. i.e. to allow other security groups to target this instance indirectly"
 }
 
 variable "database_name" {


### PR DESCRIPTION
This setting allows for existing SGs to be assigned to the RDS instance,
which allows for setups where other services have Security Groups which
have rules pointing to existing target groups, and we add this RDS instance
to that target group.

The result is the RDS is a member of multiple Security Groups, one built by this
module to control ingress rules specific to this instance, and others which are defined
elsewhere that might add common rules to multiple RDS instances, or allow this instance
to be accessed by existing egress rules on other resources which point to a common security group.