### PR TITLE
Added deletion_protection parameter for RDS instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Available targets:
 | db_options | A list of DB options to apply with an option group.  Depends on DB engine | list | `<list>` | no |
 | db_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | list | `<list>` | no |
 | db_parameter_group | Parameter group, depends on DB engine used | string | - | yes |
+| deletion_protection | Set to true to enable deletion protection on the RDS instance | string | `false` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | dns_zone_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | db_options | A list of DB options to apply with an option group.  Depends on DB engine | list | `<list>` | no |
 | db_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | list | `<list>` | no |
 | db_parameter_group | Parameter group, depends on DB engine used | string | - | yes |
+| deletion_protection | Set to true to enable deletion protection on the RDS instance | string | `false` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | dns_zone_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ resource "aws_db_instance" "default" {
   backup_retention_period     = "${var.backup_retention_period}"
   backup_window               = "${var.backup_window}"
   tags                        = "${module.label.tags}"
+  deletion_protection         = "${var.deletion_protection}"
   final_snapshot_identifier   = "${length(var.final_snapshot_identifier) > 0 ? var.final_snapshot_identifier : module.final_snapshot_label.id}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,12 @@ variable "database_port" {
   description = "Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids`"
 }
 
+variable "deletion_protection" {
+  type        = "string"
+  description = "Set to true to enable deletion protection on the RDS instance"
+  default     = "false"
+}
+
 variable "multi_az" {
   type        = "string"
   description = "Set to true if multi AZ deployment must be supported"


### PR DESCRIPTION
RDS now supports a deletion_protection flag, similar to the
termination_protection flag on EC2 instaces. If enabled, this
flag will prevent the accidental deletion of a database. This
require the terraform AWS provider be at least version 1.39.0.