### PR TITLE
Ignore changes to database password

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,10 @@ resource "aws_db_instance" "default" {
   tags                        = module.label.tags
   deletion_protection         = var.deletion_protection
   final_snapshot_identifier   = length(var.final_snapshot_identifier) > 0 ? var.final_snapshot_identifier : module.final_snapshot_label.id
+
+  lifecycle {
+    ignore_changes = ["password"]
+  }    
 }
 
 resource "aws_db_parameter_group" "default" {


### PR DESCRIPTION
## why

To use this module and not cause a re-creation, you would have to hardcode the password somewhere in your config / terraform code. This is not a secure method. Naturally if you use a secrets system this isn't an issue.

If you use the random_string resource then you would get a different password on each apply and therefore end up destroying the resource.