### PR TITLE
Adds `allowed_cidr_blocks` support to RDS SG 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | allocated_storage | The allocated storage in GBs | number | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | bool | `false` | no |
-| allowed_cidr_blocks | CIDRs to allow access to the DB instances via the created SG | list(string) | `<list>` | no |
+| allowed_cidr_blocks | The whitelisted CIDRs which to allow `ingress` traffic to the DB instance | list(string) | `<list>` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
 | associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ module "rds_instance" {
     dns_zone_id                 = "Z89FN1IW975KPE"
     host_name                   = "db"
     security_group_ids          = ["sg-xxxxxxxx"]
+    allowed_cidr_blocks         = ["XXX.XXX.XXX.XXX/32"]
     database_name               = "wordpress"
     database_user               = "admin"
     database_password           = "xxxxxxxxxxxx"
@@ -130,6 +131,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | allocated_storage | The allocated storage in GBs | number | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | bool | `false` | no |
+| allowed_cidr_blocks | CIDRs to allow access to the DB instances via the created SG | list(string) | `<list>` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
 | associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -76,6 +76,7 @@ usage: |-
       dns_zone_id                 = "Z89FN1IW975KPE"
       host_name                   = "db"
       security_group_ids          = ["sg-xxxxxxxx"]
+      allowed_cidr_blocks         = ["XXX.XXX.XXX.XXX/32"]
       database_name               = "wordpress"
       database_user               = "admin"
       database_password           = "xxxxxxxxxxxx"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allocated_storage | The allocated storage in GBs | number | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | bool | `false` | no |
-| allowed_cidr_blocks | CIDRs to allow access to the DB instances via the created SG | list(string) | `<list>` | no |
+| allowed_cidr_blocks | The whitelisted CIDRs which to allow `ingress` traffic to the DB instance | list(string) | `<list>` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
 | associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allocated_storage | The allocated storage in GBs | number | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | bool | `false` | no |
+| allowed_cidr_blocks | CIDRs to allow access to the DB instances via the created SG | list(string) | `<list>` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
 | associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,13 @@ resource "aws_security_group" "default" {
   vpc_id      = var.vpc_id
 
   ingress {
+    from_port  = var.database_port
+    to_port    = var.database_port
+    protocol   = "tcp"
+    cidr_block = var.allowed_cidr_blocks
+  }
+
+  ingress {
     from_port       = var.database_port
     to_port         = var.database_port
     protocol        = "tcp"

--- a/main.tf
+++ b/main.tf
@@ -130,10 +130,10 @@ resource "aws_security_group" "default" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port  = var.database_port
-    to_port    = var.database_port
-    protocol   = "tcp"
-    cidr_block = var.allowed_cidr_blocks
+    from_port   = var.database_port
+    to_port     = var.database_port
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidr_blocks
   }
 
   ingress {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "security_group_ids" {
   description = "The IDs of the security groups from which to allow `ingress` traffic to the DB instance"
 }
 
+variable "allowed_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "The whitelisted CIDRs which to allow `ingress` traffic to the DB instance"
+}
+
 variable "associate_security_group_ids" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
Adds `allowed_cidr_blocks` to support whitelisting IP ranges for connecting to RDS instances outside of AWS. 

This is directly similar to cloudposse/terraform-aws-rds-cluster's `allowed_cidr_blocks` https://github.com/cloudposse/terraform-aws-rds-cluster/blob/master/variables.tf#L172