### PR TITLE
Add standalone ingress/egress rules to the RDS security group. Change AWS region for tests

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,6 +1,6 @@
-region = "us-west-1"
+region = "us-east-2"
 
-availability_zones = ["us-west-1b", "us-west-1c"]
+availability_zones = ["us-east-2a", "us-east-2b"]
 
 namespace = "eg"
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -16,7 +16,7 @@ func TestExamplesComplete(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -33,12 +33,12 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	privateSubnetCidrs := terraform.OutputList(t, terraformOptions, "private_subnet_cidrs")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, []string{"172.16.0.0/18", "172.16.64.0/18"}, privateSubnetCidrs)
+	assert.Equal(t, []string{"172.16.0.0/19", "172.16.32.0/19"}, privateSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	publicSubnetCidrs := terraform.OutputList(t, terraformOptions, "public_subnet_cidrs")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, []string{"172.16.128.0/18", "172.16.192.0/18"}, publicSubnetCidrs)
+	assert.Equal(t, []string{"172.16.96.0/19", "172.16.128.0/19"}, publicSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	instanceId := terraform.Output(t, terraformOptions, "instance_id")


### PR DESCRIPTION
## what
* Add standalone ingress/egress rules to the RDS security group
* Change AWS region for tests

## why
* Inlined security group rules force re-creation when a separate rule is added to the security group in a top-level module using `aws_security_group_rule` (`aws_security_group_rule` and inline rules don't mix)

* `us-west-1` is a limited region, e.g. it has different names of AZs for different AWS accounts
