### PR TITLE
Add standalone ingress/egress rules to the RDS security group. Add `allowed_cidr_blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | allocated_storage | The allocated storage in GBs | string | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | string | `false` | no |
+| allowed_cidr_blocks | The whitelisted CIDRs which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
 | associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
@@ -328,17 +329,17 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [s2504s_homepage]: https://github.com/s2504s
-  [s2504s_avatar]: https://github.com/s2504s.png?size=150
+  [s2504s_avatar]: https://img.cloudposse.com/150x150/https://github.com/s2504s.png
   [drama17_homepage]: https://github.com/drama17
-  [drama17_avatar]: https://github.com/drama17.png?size=150
+  [drama17_avatar]: https://img.cloudposse.com/150x150/https://github.com/drama17.png
   [comeanother_homepage]: https://github.com/comeanother
-  [comeanother_avatar]: https://github.com/comeanother.png?size=150
+  [comeanother_avatar]: https://img.cloudposse.com/150x150/https://github.com/comeanother.png
   [drmikecrowe_homepage]: https://github.com/drmikecrowe
-  [drmikecrowe_avatar]: https://github.com/drmikecrowe.png?size=150
+  [drmikecrowe_avatar]: https://img.cloudposse.com/150x150/https://github.com/drmikecrowe.png
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allocated_storage | The allocated storage in GBs | string | - | yes |
 | allow_major_version_upgrade | Allow major version upgrade | string | `false` | no |
+| allowed_cidr_blocks | The whitelisted CIDRs which to allow `ingress` traffic to the DB instance | list | `<list>` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
 | associate_security_group_ids | The IDs of the existing security groups to associate with the DB instance | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -90,24 +90,42 @@ resource "aws_db_subnet_group" "default" {
 resource "aws_security_group" "default" {
   count       = "${var.enabled == "true" ? 1 : 0}"
   name        = "${module.label.id}"
-  description = "Allow inbound traffic from the security groups"
+  description = "RDS Security Group"
   vpc_id      = "${var.vpc_id}"
+  tags        = "${module.label.tags}"
+}
 
-  ingress {
-    from_port       = "${var.database_port}"
-    to_port         = "${var.database_port}"
-    protocol        = "tcp"
-    security_groups = ["${var.security_group_ids}"]
-  }
+resource "aws_security_group_rule" "ingress_security_groups" {
+  count                    = "${var.enabled == "true" ? length(var.security_group_ids) : 0}"
+  description              = "Allow inbound traffic from existing Security Groups"
+  type                     = "ingress"
+  from_port                = "${var.database_port}"
+  to_port                  = "${var.database_port}"
+  protocol                 = "tcp"
+  source_security_group_id = "${element(var.security_group_ids, count.index)}"
+  security_group_id        = "${join("", aws_security_group.default.*.id)}"
+}
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "ingress_cidr_blocks" {
+  count             = "${var.enabled == "true" && length(var.allowed_cidr_blocks) > 0 ? 1 : 0}"
+  description       = "Allow inbound traffic from CIDR blocks"
+  type              = "ingress"
+  from_port         = "${var.database_port}"
+  to_port           = "${var.database_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.allowed_cidr_blocks}"]
+  security_group_id = "${join("", aws_security_group.default.*.id)}"
+}
 
-  tags = "${module.label.tags}"
+resource "aws_security_group_rule" "egress" {
+  count             = "${var.enabled == "true" ? 1 : 0}"
+  description       = "Allow all egress traffic"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${join("", aws_security_group.default.*.id)}"
 }
 
 module "dns_host_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "security_group_ids" {
   description = "The IDs of the security groups from which to allow `ingress` traffic to the DB instance"
 }
 
+variable "allowed_cidr_blocks" {
+  type        = "list"
+  default     = []
+  description = "The whitelisted CIDRs which to allow `ingress` traffic to the DB instance"
+}
+
 variable "associate_security_group_ids" {
   type        = "list"
   default     = []


### PR DESCRIPTION
## what
* Add standalone ingress/egress rules to the RDS security group
* Add `allowed_cidr_blocks`

## why
* Inlined security group rules force re-creation when a separate rule is added to the security group in a top-level module using `aws_security_group_rule` (`aws_security_group_rule` and inline rules don't mix)

## notes
* This is for TF 0.11
* For TF 0.12, see https://github.com/cloudposse/terraform-aws-rds/releases/tag/0.14.0
