### PR TITLE
Bugfix support old postgres versions and allow upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "random_string" "default" {
 
 resource "aws_db_parameter_group" "default" {
   count     = "${(length(var.parameter_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
-  name      = "${module.label.id}${random_string.default.result}"
+  name      = "${module.label.id}${var.delimiter}${random_string.default.result}"
   family    = "${var.db_parameter_group}"
   tags      = "${module.label.tags}"
   parameter = "${var.db_parameter}"

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ resource "aws_db_instance" "default" {
 }
 
 resource "random_string" "default" {
+  count   = "${var.enabled == "true" ? 1 : 0}"
   length  = 20
   special = false
   upper   = false

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "random_string" "default" {
 
 resource "aws_db_parameter_group" "default" {
   count     = "${(length(var.parameter_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
-  name      = "${module.label.id}${var.delimiter}${random_string.default.result}"
+  name      = "${module.label.id}${var.delimiter}${join("", random_string.default.*.result)}"
   family    = "${var.db_parameter_group}"
   tags      = "${module.label.tags}"
   parameter = "${var.db_parameter}"

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_db_parameter_group" "default" {
 
 resource "aws_db_option_group" "default" {
   count                = "${(length(var.option_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
-  name                 = "${module.label.id}${var.delimiter}${random_string.default.result}"
+  name                 = "${module.label.id}${var.delimiter}${join("", random_string.default.*.result)}"
   engine_name          = "${var.engine}"
   major_engine_version = "${local.major_engine_version}"
   tags                 = "${module.label.tags}"

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,10 @@ module "final_snapshot_label" {
 }
 
 locals {
-  computed_major_engine_version = "${var.engine == "postgres" ? join(".", slice(split(".", var.engine_version), 0, 1)) : join(".", slice(split(".", var.engine_version), 0, 2))}"
+  versions                      = "${split(".", var.engine_version)}"
+  major_version                 = "${element(local.versions,0)}"
+  minor_version                 = "${length(local.versions) > 1 ? format(".%s", element(local.versions,1)) : ""}"
+  computed_major_engine_version = "${local.major_version}${(var.engine != "postgres" || local.major_version < 10) ? local.minor_version : ""}"
   major_engine_version          = "${var.major_engine_version == "" ? local.computed_major_engine_version : var.major_engine_version}"
 }
 
@@ -59,17 +62,31 @@ resource "aws_db_instance" "default" {
   final_snapshot_identifier   = "${length(var.final_snapshot_identifier) > 0 ? var.final_snapshot_identifier : module.final_snapshot_label.id}"
 }
 
+resource "random_string" "default" {
+  length  = 20
+  special = false
+  upper   = false
+
+  keepers {
+    engine_version = "${var.engine_version}"
+  }
+}
+
 resource "aws_db_parameter_group" "default" {
   count     = "${(length(var.parameter_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
-  name      = "${module.label.id}"
+  name      = "${module.label.id}${random_string.default.result}"
   family    = "${var.db_parameter_group}"
   tags      = "${module.label.tags}"
   parameter = "${var.db_parameter}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_option_group" "default" {
   count                = "${(length(var.option_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
-  name                 = "${module.label.id}"
+  name                 = "${module.label.id}${random_string.default.result}"
   engine_name          = "${var.engine}"
   major_engine_version = "${local.major_engine_version}"
   tags                 = "${module.label.tags}"

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_db_parameter_group" "default" {
 
 resource "aws_db_option_group" "default" {
   count                = "${(length(var.option_group_name) == 0 && var.enabled == "true") ? 1 : 0}"
-  name                 = "${module.label.id}${random_string.default.result}"
+  name                 = "${module.label.id}${var.delimiter}${random_string.default.result}"
   engine_name          = "${var.engine}"
   major_engine_version = "${local.major_engine_version}"
   tags                 = "${module.label.tags}"


### PR DESCRIPTION
1. The code as it exists fails for postgres engine versions below 10 because the computed_major_engine_version returns 9 instead of 9.x.   
2. It also fails for upgrades to an existing database because of issues with creating an option group with the same name, and with deleting a parameter group that is already in use.  
The changes in this pull request address the two issues listed above. 