### PR TITLE
feat: Add RDS Performance Insights arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Available targets:
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
 | option_group_name | Name of the DB option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
+| performance_insights_enabled | Specifies whether Performance Insights are enabled. | bool | `false` | no |
+| performance_insights_kms_key_id | The ARN for the KMS key to encrypt Performance Insights data. Once KMS key is set, it can never be changed. | string | `null` | no |
+| performance_insights_retention_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | number | `7` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | bool | `false` | no |
 | security_group_ids | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | list(string) | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | bool | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -39,6 +39,9 @@
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
 | option_group_name | Name of the DB option group to associate | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
+| performance_insights_enabled | Specifies whether Performance Insights are enabled. | bool | `false` | no |
+| performance_insights_kms_key_id | The ARN for the KMS key to encrypt Performance Insights data. Once KMS key is set, it can never be changed. | string | `null` | no |
+| performance_insights_retention_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | number | `7` | no |
 | publicly_accessible | Determines if database can be publicly available (NOT recommended) | bool | `false` | no |
 | security_group_ids | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | list(string) | `<list>` | no |
 | skip_final_snapshot | If true (default), no snapshot will be made before deleting DB | bool | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,10 @@ resource "aws_db_instance" "default" {
   tags                        = module.label.tags
   deletion_protection         = var.deletion_protection
   final_snapshot_identifier   = length(var.final_snapshot_identifier) > 0 ? var.final_snapshot_identifier : module.final_snapshot_label.id
+
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = var.performance_insights_enabled ? var.performance_insights_kms_key_id : null
+  performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
 }
 
 resource "aws_db_parameter_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -297,3 +297,21 @@ variable "kms_key_arn" {
   description = "The ARN of the existing KMS key to encrypt storage"
   default     = ""
 }
+
+variable "performance_insights_enabled" {
+  type        = bool
+  default     = false
+  description = "Specifies whether Performance Insights are enabled."
+}
+
+variable "performance_insights_kms_key_id" {
+  type        = string
+  default     = null
+  description = "The ARN for the KMS key to encrypt Performance Insights data. Once KMS key is set, it can never be changed."
+}
+
+variable "performance_insights_retention_period" {
+  type        = number
+  default     = 7
+  description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
+}


### PR DESCRIPTION
Motivation: Allow to configure [Performance Insights](https://aws.amazon.com/rds/performance-insights/) for RDS