### PR TITLE
Support monitoring_role_arn; required for monitoring_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -203,6 +204,7 @@ Available targets:
 | major\_engine\_version | Database MAJOR engine version, depends on engine type | `string` | `""` | no |
 | max\_allocated\_storage | The upper limit to which RDS can automatically scale the storage in GBs | `number` | `0` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. Valid Values are 0, 1, 5, 10, 15, 30, 60. | `string` | `"0"` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `string` | `null` | no |
 | multi\_az | Set to true if multi AZ deployment must be supported | `bool` | `false` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
@@ -236,6 +238,7 @@ Available targets:
 | security\_group\_id | ID of the Security Group |
 | subnet\_group\_id | ID of the Subnet Group |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -54,6 +55,7 @@
 | major\_engine\_version | Database MAJOR engine version, depends on engine type | `string` | `""` | no |
 | max\_allocated\_storage | The upper limit to which RDS can automatically scale the storage in GBs | `number` | `0` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. Valid Values are 0, 1, 5, 10, 15, 30, 60. | `string` | `"0"` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `string` | `null` | no |
 | multi\_az | Set to true if multi AZ deployment must be supported | `bool` | `false` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
@@ -87,3 +89,4 @@
 | security\_group\_id | ID of the Security Group |
 | subnet\_group\_id | ID of the Subnet Group |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ resource "aws_db_instance" "default" {
   performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
 
   monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_role_arn
 }
 
 resource "aws_db_parameter_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -340,6 +340,11 @@ variable "monitoring_interval" {
   default     = "0"
 }
 
+variable "monitoring_role_arn" {
+  type        = string
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs"
+  default     = null
+}
 
 variable "iam_database_authentication_enabled" {
   description = "Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled"


### PR DESCRIPTION
## what
* adds a `monitoring_role_arn` input variable which gets passed through to `aws_db_instance` resource

## why
* without this, when using `monitoring_interval`, you get the following error:
> InvalidParameterCombination: A MonitoringRoleARN value is required if you specify a MonitoringInterval value other than 0.

## references
* this is already [supported by `cloudposse/terraform-aws-rds-cluster`](https://github.com/cloudposse/terraform-aws-rds-cluster/blob/0.35.0/variables.tf#L233-L236)
