### PR TITLE
fix: update aws provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
 
@@ -161,7 +161,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
+| terraform | >= 0.12.0 |
 | aws | >= 2.0 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
 
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,10 +3,10 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
+| terraform | >= 0.12.0 |
 | aws | >= 2.0 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = ">= 2.0"
     template = "~> 2.0"
     null     = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws      = ">= 2.0"
-    template = "~> 2.0"
-    null     = "~> 2.0"
+    template = ">= 2.0"
+    null     = ">= 2.0"
   }
 }


### PR DESCRIPTION
## what
* Update aws provider to `>= 2.0` avoid module version conflicts when used with `>= 3.0` modules (eg. aws-eks-node-group).

## why
* This module is being used with [terraform-aws-eks-node-group](https://github.com/cloudposse/terraform-aws-eks-node-group) which needs aws provider version to be `>= 2.0` to fix version conflicts.

## references
* See cloudposse/terraform-aws-eks-node-group#41 for details. This tackles one of the modules causing the issue.

