### PR TITLE
Bump terraform-aws-route53-cluster-hostname

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns_host_name" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = length(var.dns_zone_id) > 0 && var.enabled ? true : false
   name    = var.host_name
   zone_id = var.dns_zone_id


### PR DESCRIPTION
## what
* Bump module dns_host_name from 0.5.0 to 0.7.0

## why
* terraform-aws-rds claims to support provider AWS >= 2.0
* terraform-aws-route53-cluster-hostname supports AWS ~> 2.0
* By bumping terraform-aws-route53-cluster-hostname to a version supporting AWS >= 2.0 we ensure that this RDS module's dependencies don't imply unexpected restrictions.
* terraform-aws-route53-cluster-hostname 0.6.0 would also be valid; but 0.7.0 causes no breaking changes, so it makes sense to skip ahead to the latest valid version.

