### PR TITLE
fix: use correct variable with route53-cluster-hostname

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,11 +160,11 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns_host_name" {
-  source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.8.0"
-  enabled = length(var.dns_zone_id) > 0 && module.this.enabled
-  name    = var.host_name
-  zone_id = var.dns_zone_id
-  records = coalescelist(aws_db_instance.default.*.address, [""])
-  context = module.this.context
+  source    = "cloudposse/route53-cluster-hostname/aws"
+  version   = "0.8.0"
+  enabled   = length(var.dns_zone_id) > 0 && module.this.enabled
+  host_name = var.host_name
+  zone_id   = var.dns_zone_id
+  records   = coalescelist(aws_db_instance.default.*.address, [""])
+  context   = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -160,11 +160,11 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns_host_name" {
-  source    = "cloudposse/route53-cluster-hostname/aws"
-  version   = "0.8.0"
-  enabled   = length(var.dns_zone_id) > 0 && module.this.enabled
-  host_name = var.host_name
-  zone_id   = var.dns_zone_id
-  records   = coalescelist(aws_db_instance.default.*.address, [""])
-  context   = module.this.context
+  source   = "cloudposse/route53-cluster-hostname/aws"
+  version  = "0.8.0"
+  enabled  = length(var.dns_zone_id) > 0 && module.this.enabled
+  dns_name = var.host_name
+  zone_id  = var.dns_zone_id
+  records  = coalescelist(aws_db_instance.default.*.address, [""])
+  context  = module.this.context
 }


### PR DESCRIPTION
## what
* Use `dns_name` instead of `name` while using the route53-cluster-hostname module.

## why
* The `name` parameter is not being used by the route53-cluster-hostname module invocation and results it falling back to the value of `module.this.id` rather than the default value of `db` for `host_name` within the terraform-aws-rds module.

## references
* https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/blob/master/main.tf#L3

