### PR TITLE
[auto-context] Create pull request when context.tf changes

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."


### PR DESCRIPTION
## what
- Fix `auto-context` workflow so that it creates a pull request when `context.tf` changes

## why
- Bugfix

## notes

After verifying that this works to produce a PR that is automatically merged, same fix needs to be applied to `build-harness`