### PR TITLE
Add availability zone option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "aws_db_instance" "default" {
   parameter_group_name        = length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)
   option_group_name           = length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)
   license_model               = var.license_model
+  availability_zone           = var.availability_zone
   multi_az                    = var.multi_az
   storage_type                = var.storage_type
   iops                        = var.iops

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "default" {
   parameter_group_name        = length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)
   option_group_name           = length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)
   license_model               = var.license_model
-  availability_zone           = var.availability_zone
+  availability_zone           = var.multi_az ? null : var.availability_zone
   multi_az                    = var.multi_az
   storage_type                = var.storage_type
   iops                        = var.iops

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "deletion_protection" {
   default     = false
 }
 
+variable "availability_zone" {
+  type        = string
+  description = "(Optional) The AZ for the RDS instance"
+  default     = null
+}
+
 variable "multi_az" {
   type        = bool
   description = "Set to true if multi AZ deployment must be supported"


### PR DESCRIPTION
## what
* Exposes the `aws_db_instance`'s `availability_zone` option as an option on this module.
* Ignores any value set for the `availability_zone` option if this module's `multi_az` option is set to `true`.

## why
* Being able to use this module with minimal resources initially, and scale up later when required, would be useful.

## references
closes #93

