### PR TITLE
minimum required Terraform version bumped to 0.13.0, context.tf updated, readme updated

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -43,3 +43,11 @@ change-template: |
 
 template: |
   $CHANGES
+
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,16 @@
+# https://docs.mergify.io/conditions.html
+# https://docs.mergify.io/actions.html
 pull_request_rules:
 - name: "approve automated PRs that have passed checks"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "author=cloudpossebot"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   actions:
     review:
       type: "APPROVE"
@@ -15,16 +19,17 @@ pull_request_rules:
 
 - name: "merge automated PRs when approved and tests pass"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   - "#approved-reviews-by>=1"
   - "#changes-requested-reviews-by=0"
   - "#commented-reviews-by=0"
-  - "base=master"
-  - "author=cloudpossebot"
   actions:
     merge:
       method: "squash"
@@ -38,6 +43,7 @@ pull_request_rules:
 - name: "ask to resolve conflict"
   conditions:
   - "conflict"
+  - "-closed"
   actions:
     comment:
       message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,17 +27,19 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
         fi
 
     - name: Create Pull Request
-      if: {{ steps.update.outputs.create_pull_request == 'true' }}
+      if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
+        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,86 @@
+name: Auto Format
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    container: cloudposse/build-harness:slim-latest
+    steps:
+    # Checkout the pull request branch
+    #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
+    #   the repository’s GITHUB_TOKEN, a new workflow will not run even when the repository contains
+    #   a workflow configured to run when push events occur."
+    # However, using a personal access token will cause events to be triggered.
+    # We need that to ensure a status gets posted after the auto-format commit.
+    # We also want to trigger tests if the auto-format made no changes.
+    - uses: actions/checkout@v2
+      if: github.event.pull_request.state == 'open'
+      name: Privileged Checkout
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        # Check out the PR commit, not the merge commit
+        # Use `ref` instead of `sha` to enable pushing back to `ref`
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Do all the formatting stuff
+    - name: Auto Format
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
+
+    # Commit changes (if any) to the PR branch
+    - name: Commit changes to the PR branch
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      id: commit
+      env:
+        SENDER: ${{ github.event.sender.login }}
+      run: |
+        set -x
+        output=$(git diff --name-only)
+
+        if [ -n "$output" ]; then
+          echo "Changes detected. Pushing to the PR branch"
+          git config --global user.name 'cloudpossebot'
+          git config --global user.email '11232728+cloudpossebot@users.noreply.github.com'
+          git add -A
+          git commit -m "Auto Format"
+          # Prevent looping by not pushing changes in response to changes from cloudpossebot
+          [[ $SENDER ==  "cloudpossebot" ]] || git push
+          # Set status to fail, because the push should trigger another status check,
+          # and we use success to indicate the checks are finished.
+          printf "::set-output name=%s::%s\n" "changed" "true"
+          exit 1
+        else
+          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "No changes detected"
+        fi
+
+    - name: Auto Test
+      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      # match users by ID because logins (user names) are inconsistent,
+      # for example in the REST API Renovate Bot is `renovate[bot]` but
+      # in GraphQL it is just `renovate`, plus there is a non-bot
+      # user `renovate` with ID 1832810.
+      # Mergify bot: 37929162
+      # Renovate bot: 29139614
+      # Cloudpossebot: 11232728
+      # Need to use space separators to prevent "21" from matching "112144"
+      if: >
+        contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
+        && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: cloudposse/actions
+        event-type: test-command
+        client-payload: |-
+          { "slash_command":{"args": {"unnamed": {"all": "all", "arg1": "all"}}},
+             "pull_request": ${{ toJSON(github.event.pull_request) }},
+             "github":{"payload":{"repository": ${{ toJSON(github.event.repository) }},
+                                  "comment": {"id": ""}
+                                 }
+                      }
+          }

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  semver:
+  publish:
     runs-on: ubuntu-latest
     steps:
     # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,6 +9,8 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
@@ -16,3 +18,8 @@ jobs:
         checks: "syntax,owners,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+    - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      name: "Syntax check of CODEOWNERS"
+      with:
+        checks: "syntax,duppatterns"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ The module will create:
 * DB Security Group
 * DNS Record in Route53 for the DB endpoint
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-rds/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-rds&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 
@@ -163,7 +182,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13.0 |
 | aws | >= 2.0 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -189,7 +208,7 @@ Available targets:
 | backup\_retention\_period | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
 | backup\_window | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | copy\_tags\_to\_snapshot | Copy tags from DB to a snapshot | `bool` | `true` | no |
 | database\_name | The name of the database to create when the DB instance is created | `string` | n/a | yes |
 | database\_password | (Required unless a snapshot\_identifier or replicate\_source\_db is provided) Password for the master DB user | `string` | `""` | no |
@@ -213,7 +232,9 @@ Available targets:
 | instance\_class | Class of RDS instance | `string` | n/a | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1'. Default is 0 if rds storage type is not 'io1' | `number` | `0` | no |
 | kms\_key\_arn | The ARN of the existing KMS key to encrypt storage | `string` | `""` | no |
+| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | license\_model | License model for this DB. Optional, but required for some DB Engines. Valid values: license-included \| bring-your-own-license \| general-public-license | `string` | `""` | no |
 | maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | `string` | `"Mon:03:00-Mon:04:00"` | no |
 | major\_engine\_version | Database MAJOR engine version, depends on engine type | `string` | `""` | no |

--- a/context.tf
+++ b/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.1" // requires Terraform >= 0.12.26
+  version = "0.23.0" // requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -54,6 +54,8 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
+    label_key_case      = string
+    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -68,6 +70,8 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -76,6 +80,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -165,4 +179,33 @@ variable "id_length_limit" {
   EOT
 }
 
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`. 
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13.0 |
 | aws | >= 2.0 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -29,7 +29,7 @@
 | backup\_retention\_period | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
 | backup\_window | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | copy\_tags\_to\_snapshot | Copy tags from DB to a snapshot | `bool` | `true` | no |
 | database\_name | The name of the database to create when the DB instance is created | `string` | n/a | yes |
 | database\_password | (Required unless a snapshot\_identifier or replicate\_source\_db is provided) Password for the master DB user | `string` | `""` | no |
@@ -53,7 +53,9 @@
 | instance\_class | Class of RDS instance | `string` | n/a | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1'. Default is 0 if rds storage type is not 'io1' | `number` | `0` | no |
 | kms\_key\_arn | The ARN of the existing KMS key to encrypt storage | `string` | `""` | no |
+| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | license\_model | License model for this DB. Optional, but required for some DB Engines. Valid values: license-included \| bring-your-own-license \| general-public-license | `string` | `""` | no |
 | maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | `string` | `"Mon:03:00-Mon:04:00"` | no |
 | major\_engine\_version | Database MAJOR engine version, depends on engine type | `string` | `""` | no |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.1" // requires Terraform >= 0.12.26
+  version = "0.23.0" // requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -54,6 +54,8 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
+    label_key_case      = string
+    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -68,6 +70,8 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -76,6 +80,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -165,4 +179,33 @@ variable "id_length_limit" {
   EOT
 }
 
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`. 
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "final_snapshot_label" {
   source     = "cloudposse/label/null"
-  version    = "0.22.1"
+  version    = "0.23.0"
   attributes = ["final", "snapshot"]
   context    = module.this.context
 }
@@ -161,7 +161,7 @@ resource "aws_security_group_rule" "egress" {
 
 module "dns_host_name" {
   source   = "cloudposse/route53-cluster-hostname/aws"
-  version  = "0.10.0"
+  version  = "0.11.0"
   enabled  = length(var.dns_zone_id) > 0 && module.this.enabled
   dns_name = var.host_name
   zone_id  = var.dns_zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
- update context.tf to v0.23.0 
- minimum required Terraform version bumped to 0.13.0 
- readme updated, Bridgecrew compliance badges added

## why
- It allows for setting the letter case of tag names and labels
- we have dropped support for Terraform 0.12
- To be able see and fix the recommendations from Bridgecrew so we can position our modules as standards compliant


Supersedes and closes #96 
Supersedes and closes #97 
Supersedes and closes #98 

