### PR TITLE
create_before_destroy for parameter groups, explicit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dns_host_name | cloudposse/route53-cluster-hostname/aws | 0.12.0 |
+| final_snapshot_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) |
+| [aws_db_option_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) |
+| [aws_db_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) |
+| [aws_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -274,7 +293,6 @@ Available targets:
 | parameter\_group\_id | ID of the Parameter Group |
 | security\_group\_id | ID of the Security Group |
 | subnet\_group\_id | ID of the Subnet Group |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,25 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dns_host_name | cloudposse/route53-cluster-hostname/aws | 0.12.0 |
+| final_snapshot_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) |
+| [aws_db_option_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) |
+| [aws_db_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) |
+| [aws_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -95,5 +114,4 @@
 | parameter\_group\_id | ID of the Parameter Group |
 | security\_group\_id | ID of the Security Group |
 | subnet\_group\_id | ID of the Subnet Group |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_db_instance" "default" {
 
   depends_on = [
     aws_db_subnet_group.default,
-    aws_db_security_group.default,
+    aws_security_group.default,
     aws_db_parameter_group.default,
     aws_db_option_group.default
   ]


### PR DESCRIPTION
## what
* Make parameter groups `create_before_destroy`
* Make the name for parameter & option groups unique to ensure we can create new one's
* Add explicit dependencies
 
## why
* You cannot delete a parameter/option group while it is in use, but you can update a database with a new parameter/option group, so in order to change parameter/option groups, you need to create a new one, install it, then delete the old one.
* Some update and destroy operations were failing because resources were being deleted in the wrong order.

## references
* The same changes have been done in https://github.com/cloudposse/terraform-aws-rds-cluster/pull/110 earlier

