### PR TITLE
Add `create_before_destroy` for parameter group. Make subnet group optional

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -56,3 +56,10 @@ pull_request_rules:
       changes_requested: true
       approved: true
       message: "This Pull Request has been updated, so we're dismissing all reviews."
+
+- name: "close Pull Requests without files changed"
+  conditions:
+    - "#files=0"
+  actions:
+    close:
+      message: "This pull request has been automatically closed by Mergify because there are no longer any changes."

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-format:
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:slim-latest
+    container: cloudposse/build-harness:latest
     steps:
     # Checkout the pull request branch
     #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
@@ -29,6 +29,8 @@ jobs:
     - name: Auto Format
       if: github.event.pull_request.state == 'open'
       shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,23 @@ name: auto-release
 on:
   push:
     branches:
-    - master
+      - master
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: true
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Get PR from merged commit to master
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
+        with:
+          publish: true
+          prerelease: false
+          config-name: auto-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2019 Cloud Posse, LLC
+   Copyright 2017-2021 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Available targets:
 | associate\_security\_group\_ids | The IDs of the existing security groups to associate with the DB instance | `list(string)` | `[]` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | auto\_minor\_version\_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | `bool` | `true` | no |
-| availability\_zone | The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic | `string` | `null` | no |
+| availability\_zone | The AZ for the RDS instance. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2 Classic | `string` | `null` | no |
 | backup\_retention\_period | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
 | backup\_window | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
@@ -237,6 +237,7 @@ Available targets:
 | db\_options | A list of DB options to apply with an option group. Depends on DB engine | <pre>list(object({<br>    db_security_group_memberships  = list(string)<br>    option_name                    = string<br>    port                           = number<br>    version                        = string<br>    vpc_security_group_memberships = list(string)<br><br>    option_settings = list(object({<br>      name  = string<br>      value = string<br>    }))<br>  }))</pre> | `[]` | no |
 | db\_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
 | db\_parameter\_group | The DB parameter group family name. The value depends on DB engine used. See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value. | `string` | n/a | yes |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone` | `string` | `null` | no |
 | deletion\_protection | Set to true to enable deletion protection on the RDS instance | `bool` | `false` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | dns\_zone\_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | `string` | `""` | no |
@@ -277,7 +278,7 @@ Available targets:
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | storage\_encrypted | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified | `bool` | `true` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD) | `string` | `"standard"` | no |
-| subnet\_ids | List of subnets for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify either `subnet_ids` or `availability_zone` | `list(string)` | `[]` | no |
+| subnet\_ids | List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone` | `list(string)` | `[]` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID the DB instance will be created in | `string` | n/a | yes |
 
@@ -293,7 +294,7 @@ Available targets:
 | option\_group\_id | ID of the Option Group |
 | parameter\_group\_id | ID of the Parameter Group |
 | security\_group\_id | ID of the Security Group |
-| subnet\_group\_id | ID of the Subnet Group |
+| subnet\_group\_id | ID of the created Subnet Group |
 <!-- markdownlint-restore -->
 
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Available targets:
 | associate\_security\_group\_ids | The IDs of the existing security groups to associate with the DB instance | `list(string)` | `[]` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | auto\_minor\_version\_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | `bool` | `true` | no |
+| availability\_zone | The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic | `string` | `null` | no |
 | backup\_retention\_period | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
 | backup\_window | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
@@ -276,7 +277,7 @@ Available targets:
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | storage\_encrypted | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified | `bool` | `true` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD) | `string` | `"standard"` | no |
-| subnet\_ids | List of subnets for the DB | `list(string)` | n/a | yes |
+| subnet\_ids | List of subnets for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify either `subnet_ids` or `availability_zone` | `list(string)` | `[]` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID the DB instance will be created in | `string` | n/a | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -45,6 +45,7 @@
 | associate\_security\_group\_ids | The IDs of the existing security groups to associate with the DB instance | `list(string)` | `[]` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | auto\_minor\_version\_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | `bool` | `true` | no |
+| availability\_zone | The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic | `string` | `null` | no |
 | backup\_retention\_period | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
 | backup\_window | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
@@ -97,7 +98,7 @@
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | storage\_encrypted | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified | `bool` | `true` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD) | `string` | `"standard"` | no |
-| subnet\_ids | List of subnets for the DB | `list(string)` | n/a | yes |
+| subnet\_ids | List of subnets for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify either `subnet_ids` or `availability_zone` | `list(string)` | `[]` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID the DB instance will be created in | `string` | n/a | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -45,7 +45,7 @@
 | associate\_security\_group\_ids | The IDs of the existing security groups to associate with the DB instance | `list(string)` | `[]` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | auto\_minor\_version\_upgrade | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | `bool` | `true` | no |
-| availability\_zone | The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic | `string` | `null` | no |
+| availability\_zone | The AZ for the RDS instance. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2 Classic | `string` | `null` | no |
 | backup\_retention\_period | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
 | backup\_window | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
@@ -58,6 +58,7 @@
 | db\_options | A list of DB options to apply with an option group. Depends on DB engine | <pre>list(object({<br>    db_security_group_memberships  = list(string)<br>    option_name                    = string<br>    port                           = number<br>    version                        = string<br>    vpc_security_group_memberships = list(string)<br><br>    option_settings = list(object({<br>      name  = string<br>      value = string<br>    }))<br>  }))</pre> | `[]` | no |
 | db\_parameter | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
 | db\_parameter\_group | The DB parameter group family name. The value depends on DB engine used. See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value. | `string` | n/a | yes |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone` | `string` | `null` | no |
 | deletion\_protection | Set to true to enable deletion protection on the RDS instance | `bool` | `false` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | dns\_zone\_id | The ID of the DNS Zone in Route53 where a new DNS record will be created for the DB host name | `string` | `""` | no |
@@ -98,7 +99,7 @@
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | storage\_encrypted | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified | `bool` | `true` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD) | `string` | `"standard"` | no |
-| subnet\_ids | List of subnets for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify either `subnet_ids` or `availability_zone` | `list(string)` | `[]` | no |
+| subnet\_ids | List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone` | `list(string)` | `[]` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID the DB instance will be created in | `string` | n/a | yes |
 
@@ -114,5 +115,5 @@
 | option\_group\_id | ID of the Option Group |
 | parameter\_group\_id | ID of the Parameter Group |
 | security\_group\_id | ID of the Security Group |
-| subnet\_group\_id | ID of the Subnet Group |
+| subnet\_group\_id | ID of the created Subnet Group |
 <!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,27 +3,30 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.18.2"
-  context    = module.this.context
+  source  = "cloudposse/vpc/aws"
+  version = "0.21.1"
+
   cidr_block = "172.16.0.0/16"
+
+  context = module.this.context
 }
 
 module "subnets" {
-  source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.34.0"
-  context              = module.this.context
+  source  = "cloudposse/dynamic-subnets/aws"
+  version = "0.38.0"
+
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
   cidr_block           = module.vpc.vpc_cidr_block
   nat_gateway_enabled  = false
   nat_instance_enabled = false
+
+  context = module.this.context
 }
 
 module "rds_instance" {
   source              = "../../"
-  context             = module.this.context
   database_name       = var.database_name
   database_user       = var.database_user
   database_password   = var.database_password
@@ -41,6 +44,7 @@ module "rds_instance" {
   subnet_ids          = module.subnets.private_subnet_ids
   security_group_ids  = [module.vpc.vpc_default_security_group_id]
   apply_immediately   = var.apply_immediately
+  availability_zone   = var.availability_zone
 
   db_parameter = [
     {
@@ -54,4 +58,6 @@ module "rds_instance" {
       apply_method = "immediate"
     }
   ]
+
+  context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -26,25 +26,26 @@ module "subnets" {
 }
 
 module "rds_instance" {
-  source              = "../../"
-  database_name       = var.database_name
-  database_user       = var.database_user
-  database_password   = var.database_password
-  database_port       = var.database_port
-  multi_az            = var.multi_az
-  storage_type        = var.storage_type
-  allocated_storage   = var.allocated_storage
-  storage_encrypted   = var.storage_encrypted
-  engine              = var.engine
-  engine_version      = var.engine_version
-  instance_class      = var.instance_class
-  db_parameter_group  = var.db_parameter_group
-  publicly_accessible = var.publicly_accessible
-  vpc_id              = module.vpc.vpc_id
-  subnet_ids          = module.subnets.private_subnet_ids
-  security_group_ids  = [module.vpc.vpc_default_security_group_id]
-  apply_immediately   = var.apply_immediately
-  availability_zone   = var.availability_zone
+  source               = "../../"
+  database_name        = var.database_name
+  database_user        = var.database_user
+  database_password    = var.database_password
+  database_port        = var.database_port
+  multi_az             = var.multi_az
+  storage_type         = var.storage_type
+  allocated_storage    = var.allocated_storage
+  storage_encrypted    = var.storage_encrypted
+  engine               = var.engine
+  engine_version       = var.engine_version
+  instance_class       = var.instance_class
+  db_parameter_group   = var.db_parameter_group
+  publicly_accessible  = var.publicly_accessible
+  vpc_id               = module.vpc.vpc_id
+  subnet_ids           = module.subnets.private_subnet_ids
+  security_group_ids   = [module.vpc.vpc_default_security_group_id]
+  apply_immediately    = var.apply_immediately
+  availability_zone    = var.availability_zone
+  db_subnet_group_name = var.db_subnet_group_name
 
   db_parameter = [
     {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -15,7 +15,7 @@ output "instance_endpoint" {
 
 output "subnet_group_id" {
   value       = module.rds_instance.subnet_group_id
-  description = "ID of the Subnet Group"
+  description = "ID of the created Subnet Group"
 }
 
 output "security_group_id" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -40,7 +40,13 @@ variable "multi_az" {
 variable "availability_zone" {
   type        = string
   default     = null
-  description = "The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic"
+  description = "The AZ for the RDS instance. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2 Classic"
+}
+
+variable "db_subnet_group_name" {
+  type        = string
+  default     = null
+  description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`"
 }
 
 variable "storage_type" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -37,6 +37,12 @@ variable "multi_az" {
   description = "Set to true if multi AZ deployment must be supported"
 }
 
+variable "availability_zone" {
+  type        = string
+  default     = null
+  description = "The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic"
+}
+
 variable "storage_type" {
   type        = string
   description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD)"

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,8 @@ locals {
   db_subnet_group_name = local.db_subnet_group_name_provided ? var.db_subnet_group_name : (
     local.subnet_ids_provided ? join("", aws_db_subnet_group.default.*.name) : null
   )
+
+  availability_zone = var.multi_az ? null : var.availability_zone
 }
 
 resource "aws_db_instance" "default" {
@@ -41,7 +43,7 @@ resource "aws_db_instance" "default" {
   )
 
   db_subnet_group_name = local.db_subnet_group_name
-  availability_zone    = var.availability_zone
+  availability_zone    = local.availability_zone
 
   ca_cert_identifier          = var.ca_cert_identifier
   parameter_group_name        = length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "instance_endpoint" {
 
 output "subnet_group_id" {
   value       = join("", aws_db_subnet_group.default.*.id)
-  description = "ID of the Subnet Group"
+  description = "ID of the created Subnet Group"
 }
 
 output "security_group_id" {

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -1,7 +1,10 @@
 package test
 
 import (
+	"math/rand"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -11,12 +14,20 @@ import (
 func TestExamplesComplete(t *testing.T) {
 	t.Parallel()
 
+	rand.Seed(time.Now().UnixNano())
+
+	randId := strconv.Itoa(rand.Intn(100000))
+	attributes := []string{randId}
+
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -43,20 +54,20 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	instanceId := terraform.Output(t, terraformOptions, "instance_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-rds-test", instanceId)
+	assert.Equal(t, "eg-test-rds-test-"+randId, instanceId)
 
 	// Run `terraform output` to get the value of an output variable
 	optionGroupId := terraform.Output(t, terraformOptions, "option_group_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-rds-test", optionGroupId)
+	assert.Contains(t, optionGroupId, "eg-test-rds-test")
 
 	// Run `terraform output` to get the value of an output variable
 	parameterGroupId := terraform.Output(t, terraformOptions, "parameter_group_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-rds-test", parameterGroupId)
+	assert.Contains(t, parameterGroupId, "eg-test-rds-test")
 
 	// Run `terraform output` to get the value of an output variable
 	subnetGroupId := terraform.Output(t, terraformOptions, "subnet_group_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-rds-test", subnetGroupId)
+	assert.Equal(t, "eg-test-rds-test-"+randId, subnetGroupId)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -142,8 +142,15 @@ variable "publicly_accessible" {
 }
 
 variable "subnet_ids" {
-  description = "List of subnets for the DB"
+  description = "List of subnets for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify either `subnet_ids` or `availability_zone`"
   type        = list(string)
+  default     = []
+}
+
+variable "availability_zone" {
+  type        = string
+  default     = null
+  description = "The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic"
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,7 @@ variable "publicly_accessible" {
 }
 
 variable "subnet_ids" {
-  description = "List of subnets for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify either `subnet_ids` or `availability_zone`"
+  description = "List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`"
   type        = list(string)
   default     = []
 }
@@ -150,7 +150,13 @@ variable "subnet_ids" {
 variable "availability_zone" {
   type        = string
   default     = null
-  description = "The AZ for the RDS instance. Specify either `subnet_ids` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2-Classic"
+  description = "The AZ for the RDS instance. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`. If `availability_zone` is provided, the instance will be placed into the default VPC or EC2 Classic"
+}
+
+variable "db_subnet_group_name" {
+  type        = string
+  default     = null
+  description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`"
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
## what
* Add `create_before_destroy` for parameter group
* Make the names for parameter & option groups unique
* Make subnet group optional
* Bump module versions
* Update example and terratest

## why
* You cannot delete a parameter/option group while it is in use, but you can update a database with a new parameter/option group, so in order to change parameter/option groups, you need to create a new one, install it, then delete the old one
* Some update and destroy operations were failing because resources were being deleted in the wrong order
* If `var.db_subnet_group_name` is provided, use it and don't create a new Subnet Group
* If `var.availability_zone` is provided (and `var.db_subnet_group_name` and `var.subnet_ids` are not), use `var.availability_zone` to place the instance into the default VPC or EC2 Classic

## related
* Cloes #93 
* Closes #107
* Closes #108 
* Closes #109 

