### PR TITLE
Remove unused provider: hashicorp/template

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"


### PR DESCRIPTION
## what
Removed an unused terraform provider: hashicorp/template

## why
This provider was not used anywhere in the module. It is also deprecated and there is no `darwin_arm64` version available, so I was unable to use this module with an M1 mac

