### PR TITLE
Do not create option groups if engine is PostgreSQL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_db_parameter_group" "default" {
 }
 
 resource "aws_db_option_group" "default" {
-  count = !local.is_postgres && length(var.option_group_name) == 0 && module.this.enabled ? 1 : 0
+  count = ! local.is_postgres && length(var.option_group_name) == 0 && module.this.enabled ? 1 : 0
 
   name_prefix          = "${module.this.id}${module.this.delimiter}"
   engine_name          = var.engine
@@ -147,7 +147,7 @@ resource "aws_db_option_group" "default" {
 }
 
 resource "aws_db_subnet_group" "default" {
-  count = module.this.enabled && local.subnet_ids_provided && !local.db_subnet_group_name_provided ? 1 : 0
+  count = module.this.enabled && local.subnet_ids_provided && ! local.db_subnet_group_name_provided ? 1 : 0
 
   name       = module.this.id
   subnet_ids = var.subnet_ids


### PR DESCRIPTION
## what
* Disables de creation of options groups when the engine is PostgreSQL

## why
* PostgreSQL does not use options and option groups. PostgreSQL uses extensions and modules to provide additional features. Creating them will raise an error.

## references
* https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html

