### PR TITLE
Fix description for engine_version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Available targets:
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | Database engine type. Required unless a `snapshot_identifier` or `replicate_source_db` is provided. | `string` | `null` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Database engine version, depends on engine type. Required unless a `snapshot_identifier` or `replicate_source_db` is provided. | `string` | n/a | yes |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Database engine version, depends on engine type. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | Final snapshot identifier e.g.: some-db-final-snapshot-2019-06-26-06-05 | `string` | `""` | no |
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | The DB host name created in Route53 | `string` | `"db"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -67,7 +67,7 @@
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | Database engine type. Required unless a `snapshot_identifier` or `replicate_source_db` is provided. | `string` | `null` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Database engine version, depends on engine type. Required unless a `snapshot_identifier` or `replicate_source_db` is provided. | `string` | n/a | yes |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Database engine version, depends on engine type. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | Final snapshot identifier e.g.: some-db-final-snapshot-2019-06-26-06-05 | `string` | `""` | no |
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | The DB host name created in Route53 | `string` | `"db"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "engine" {
 
 variable "engine_version" {
   type        = string
-  description = "Database engine version, depends on engine type. Required unless a `snapshot_identifier` or `replicate_source_db` is provided."
+  description = "Database engine version, depends on engine type."
   # http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
 }
 


### PR DESCRIPTION
## what

- Fix issue https://github.com/cloudposse/terraform-aws-rds/issues/154 . 

Fix description for [engine_version](https://github.com/cloudposse/terraform-aws-rds/tree/0.42.0#input_engine_version) parameter. Delete this sentence for [engine_version](https://github.com/cloudposse/terraform-aws-rds/tree/0.42.0#input_engine_version):

> Required unless a snapshot_identifier or replicate_source_db is provided.

## why

- According to the official documentation (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version), there is no mentioning that it doesn't need to specify engine_version when you specified snapshot_identifier.

## references

- https://github.com/cloudposse/terraform-aws-rds/issues/154
