### PR TITLE
fix: add commas to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ module "rds_instance" {
     backup_window               = "22:00-03:00"
 
     db_parameter = [
-      { name  = "myisam_sort_buffer_size"   value = "1048576" },
-      { name  = "sort_buffer_size"          value = "2097152" }
+      { name  = "myisam_sort_buffer_size",   value = "1048576" },
+      { name  = "sort_buffer_size",          value = "2097152" }
     ]
 
     db_options = [
       { option_name = "MARIADB_AUDIT_PLUGIN"
           option_settings = [
-            { name = "SERVER_AUDIT_EVENTS"           value = "CONNECT" },
-            { name = "SERVER_AUDIT_FILE_ROTATIONS"   value = "37" }
+            { name = "SERVER_AUDIT_EVENTS",           value = "CONNECT" },
+            { name = "SERVER_AUDIT_FILE_ROTATIONS",   value = "37" }
           ]
       }
     ]


### PR DESCRIPTION
Add commas to the example to fix syntax error due to missing line break

## what
- Added commas to line 40, 41, 47, 48 of the example of usage in the README, each time after the name value

## why
- My Editor mentioned the syntax error and after `terraform init`it also complained about it with 
`
╷
│ Error: Missing attribute separator
│ 
│   on main.tf line 40, in module "rds_instance":
│   40:       { name  = "myisam_sort_buffer_size"   value = "1048576" },
│ 
│ Expected a newline or comma to mark the beginning of the next attribute.
`
so I added the commas it asked me for.

## references
NoN
