### PR TITLE
feat(rds): add database_insights_mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ resource "aws_db_instance" "default" {
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_kms_key_id       = var.performance_insights_enabled ? var.performance_insights_kms_key_id : null
   performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
+  database_insights_mode                = var.database_insights_mode
 
   monitoring_interval = var.monitoring_interval
   monitoring_role_arn = var.monitoring_role_arn

--- a/variables.tf
+++ b/variables.tf
@@ -315,6 +315,20 @@ variable "performance_insights_retention_period" {
   description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
 }
 
+variable "database_insights_mode" {
+  type        = string
+  default     = null
+  description = "The mode for CloudWatch Database Insights. Valid values: 'standard', 'advanced', or null."
+  validation {
+    condition     = (
+      var.database_insights_mode == null || (
+        contains(["standard", "advanced"], var.database_insights_mode)
+      )
+    )
+    error_message = "database_insights_mode must be one of: 'standard', 'advanced', or null."
+  }
+}
+
 variable "enabled_cloudwatch_logs_exports" {
   type        = list(string)
   default     = []

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.92.0"
     }
   }
 }


### PR DESCRIPTION
## what

Add `database_insights_mode`.

## why

- AWS is asking customers to migrate from the rds performance insights to the cloudwatch performance insights by November 2025. This variable will allow for migrating.

## references

- `closes #194` 
- https://github.com/terraform-aws-modules/terraform-aws-rds/pull/590
- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DatabaseInsights.html
