### PR TITLE
fix: db_parameter_group should be optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,7 @@ variable "instance_class" {
 # We're "cloning" default ones, but we need to specify which should be copied
 variable "db_parameter_group" {
   type        = string
+  default     = null
   description = "The DB parameter group family name. The value depends on DB engine used. See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value."
   # "mysql5.6"
   # "postgres9.5"


### PR DESCRIPTION
See image below. `var.db_parameter_group` is only used if `var.parameter_group_name` isn't specified.

I have a use case where I specify the `var.parameter_group_name` (aka I pass in my own custom parameter group), so I shouldn't need to pass in `var.db_parameter_group` so it should be optional.

<img width="940" height="621" alt="image" src="https://github.com/user-attachments/assets/f7487f02-be66-48b6-8806-b054e7e14ae5" />
