### PR TITLE
feat(rds_instance): support blue green deployments

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -39,3 +39,5 @@ db_parameter_group = "mysql5.7"
 publicly_accessible = false
 
 apply_immediately = true
+
+blue_green_update_enabled = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -26,26 +26,27 @@ module "subnets" {
 }
 
 module "rds_instance" {
-  source               = "../../"
-  database_name        = var.database_name
-  database_user        = var.database_user
-  database_password    = var.database_password
-  database_port        = var.database_port
-  multi_az             = var.multi_az
-  storage_type         = var.storage_type
-  allocated_storage    = var.allocated_storage
-  storage_encrypted    = var.storage_encrypted
-  engine               = var.engine
-  engine_version       = var.engine_version
-  instance_class       = var.instance_class
-  db_parameter_group   = var.db_parameter_group
-  publicly_accessible  = var.publicly_accessible
-  vpc_id               = module.vpc.vpc_id
-  subnet_ids           = module.subnets.private_subnet_ids
-  security_group_ids   = [module.vpc.vpc_default_security_group_id]
-  apply_immediately    = var.apply_immediately
-  availability_zone    = var.availability_zone
-  db_subnet_group_name = var.db_subnet_group_name
+  source                    = "../../"
+  database_name             = var.database_name
+  database_user             = var.database_user
+  database_password         = var.database_password
+  database_port             = var.database_port
+  multi_az                  = var.multi_az
+  storage_type              = var.storage_type
+  allocated_storage         = var.allocated_storage
+  storage_encrypted         = var.storage_encrypted
+  engine                    = var.engine
+  engine_version            = var.engine_version
+  instance_class            = var.instance_class
+  db_parameter_group        = var.db_parameter_group
+  publicly_accessible       = var.publicly_accessible
+  vpc_id                    = module.vpc.vpc_id
+  subnet_ids                = module.subnets.private_subnet_ids
+  security_group_ids        = [module.vpc.vpc_default_security_group_id]
+  apply_immediately         = var.apply_immediately
+  availability_zone         = var.availability_zone
+  db_subnet_group_name      = var.db_subnet_group_name
+  blue_green_update_enabled = var.blue_green_update_enabled
 
   db_parameter = [
     {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -109,3 +109,10 @@ variable "apply_immediately" {
   type        = bool
   description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
 }
+
+variable "blue_green_update_enabled" {
+  type        = bool
+  description = "Enables low-downtime updates using RDS Blue/Green deployments. Low-downtime updates are only available for DB Instances using MySQL, MariaDB and PostgreSQL, as other engines are not supported by RDS Blue/Green deployments. They cannot be used with DB Instances with replicas."
+  default     = false
+}
+

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,15 @@ resource "aws_db_instance" "default" {
   monitoring_interval = var.monitoring_interval
   monitoring_role_arn = var.monitoring_role_arn
 
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html
+  dynamic "blue_green_update" {
+    for_each = var.blue_green_update_enabled ? [1] : []
+
+    content {
+      enabled = true
+    }
+  }
+
   dynamic "restore_to_point_in_time" {
     for_each = var.snapshot_identifier == null && var.restore_to_point_in_time != null ? [1] : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -388,6 +388,12 @@ variable "timeouts" {
   }
 }
 
+variable "blue_green_update_enabled" {
+  type        = bool
+  description = "Enables low-downtime updates using RDS Blue/Green deployments. Low-downtime updates are only available for DB Instances using MySQL, MariaDB and PostgreSQL, as other engines are not supported by RDS Blue/Green deployments. They cannot be used with DB Instances with replicas."
+  default     = false
+}
+
 variable "restore_to_point_in_time" {
   type = object({
     restore_time                             = optional(string, null)


### PR DESCRIPTION
## what

- Add support for blue green deployments by creating a boolean input for `blue_green_update_enabled`
- Update examples with usage

## why

- Enables low-downtime updates using RDS Blue/Green deployments. Low-downtime updates are only available for DB Instances using MySQL, MariaDB and PostgreSQL, as other engines are not supported by RDS Blue/Green deployments. They cannot be used with DB Instances with replicas.

## references

- [Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#low-downtime-updates)
- Closes #161 